### PR TITLE
feat: Object results

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/result/BigIntegerResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/BigIntegerResult.java
@@ -1,0 +1,17 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.probe.result;
+
+import java.math.BigInteger;
+
+public class BigIntegerResult extends ObjectResult<BigInteger> {
+    public BigIntegerResult(BigInteger value, String name) {
+        super(value, name);
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/IntegerResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/IntegerResult.java
@@ -1,0 +1,15 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.probe.result;
+
+public class IntegerResult extends ObjectResult<Integer> {
+    public IntegerResult(Integer value, String name) {
+        super(value, name);
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
@@ -8,9 +8,6 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 /**
@@ -18,8 +15,6 @@ import java.util.List;
  *
  * @param <T> the type of the list elements.
  */
-@XmlRootElement(name = "result")
-@XmlAccessorType(XmlAccessType.FIELD)
 public class ListResult<T> extends CollectionResult<T> {
 
     /**

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/LongResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/LongResult.java
@@ -1,0 +1,15 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.probe.result;
+
+public class LongResult extends ObjectResult<Long> {
+    public LongResult(Long value, String name) {
+        super(value, name);
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
@@ -8,9 +8,6 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -20,8 +17,6 @@ import java.util.Map;
  * @param <S> the key types of the map.
  * @param <T> the value types of the map.
  */
-@XmlRootElement(name = "result")
-@XmlAccessorType(XmlAccessType.FIELD)
 public class MapResult<S, T> implements TestResult, Serializable {
 
     private final String name;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
@@ -24,6 +24,10 @@ public class ObjectResult<T> implements TestResult, Serializable {
         return value;
     }
 
+    public <S> S getValue(Class<S> valueClass) {
+        return valueClass.cast(value);
+    }
+
     @Override
     public String getName() {
         return name;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
@@ -10,7 +10,7 @@ package de.rub.nds.scanner.core.probe.result;
 
 import java.io.Serializable;
 
-public class ObjectResult<T> implements TestResult, Serializable{
+public class ObjectResult<T> implements TestResult, Serializable {
 
     private final String name;
     protected final T value;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
@@ -1,0 +1,31 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.probe.result;
+
+import java.io.Serializable;
+
+public class ObjectResult<T> implements TestResult, Serializable{
+
+    private final String name;
+    protected final T value;
+
+    public ObjectResult(T value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
@@ -8,9 +8,6 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Set;
 
 /**
@@ -18,8 +15,6 @@ import java.util.Set;
  *
  * @param <T> the type of which the SetResult consists.
  */
-@XmlRootElement(name = "result")
-@XmlAccessorType(XmlAccessType.FIELD)
 public class SetResult<T> extends CollectionResult<T> {
 
     /**

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/StringResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/StringResult.java
@@ -1,0 +1,15 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.probe.result;
+
+public class StringResult extends ObjectResult<String> {
+    public StringResult(String value, String name) {
+        super(value, name);
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
@@ -8,8 +8,6 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -17,7 +15,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * property.
  */
 @XmlRootElement(name = "result")
-@XmlAccessorType(XmlAccessType.FIELD)
 public enum TestResults implements TestResult {
     TRUE,
     FALSE,

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
@@ -13,12 +13,8 @@ import de.rub.nds.scanner.core.passive.ExtractedValueContainer;
 import de.rub.nds.scanner.core.passive.TrackableValue;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.ProbeType;
-import de.rub.nds.scanner.core.probe.result.CollectionResult;
-import de.rub.nds.scanner.core.probe.result.ListResult;
-import de.rub.nds.scanner.core.probe.result.MapResult;
-import de.rub.nds.scanner.core.probe.result.SetResult;
-import de.rub.nds.scanner.core.probe.result.TestResult;
-import de.rub.nds.scanner.core.probe.result.TestResults;
+import de.rub.nds.scanner.core.probe.result.*;
+import java.math.BigInteger;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -50,6 +46,39 @@ public class ScanReport extends Observable {
 
     public synchronized TestResult getResult(AnalyzedProperty property) {
         return resultMap.getOrDefault(property, TestResults.NOT_TESTED_YET);
+    }
+
+    public synchronized ObjectResult<?> getObjectResult(AnalyzedProperty property) {
+        TestResult result = resultMap.get(property);
+        return result instanceof ObjectResult ? (ObjectResult<?>) result : null;
+    }
+
+    public synchronized <T> ObjectResult<T> getObjectResult(
+            AnalyzedProperty property, Class<T> valueClass) {
+        ObjectResult<?> result = getObjectResult(property);
+        return result != null
+                ? new ObjectResult<>(valueClass.cast(result.getValue()), result.getName())
+                : null;
+    }
+
+    public synchronized BigIntegerResult getBigIntegerResult(AnalyzedProperty property) {
+        TestResult result = resultMap.get(property);
+        return result instanceof BigIntegerResult ? (BigIntegerResult) result : null;
+    }
+
+    public synchronized IntegerResult getIntegerResult(AnalyzedProperty property) {
+        TestResult result = resultMap.get(property);
+        return result instanceof IntegerResult ? (IntegerResult) result : null;
+    }
+
+    public synchronized LongResult getLongResult(AnalyzedProperty property) {
+        TestResult result = resultMap.get(property);
+        return result instanceof LongResult ? (LongResult) result : null;
+    }
+
+    public synchronized StringResult getStringResult(AnalyzedProperty property) {
+        TestResult result = resultMap.get(property);
+        return result instanceof StringResult ? (StringResult) result : null;
     }
 
     public synchronized CollectionResult<?> getCollectionResult(AnalyzedProperty property) {
@@ -139,6 +168,22 @@ public class ScanReport extends Observable {
                                 : TestResults.UNCERTAIN);
     }
 
+    public synchronized void putResult(AnalyzedProperty property, BigInteger result) {
+        this.putResult(property, new BigIntegerResult(result, property.getName()));
+    }
+
+    public synchronized void putResult(AnalyzedProperty property, Integer result) {
+        this.putResult(property, new IntegerResult(result, property.getName()));
+    }
+
+    public synchronized void putResult(AnalyzedProperty property, Long result) {
+        this.putResult(property, new LongResult(result, property.getName()));
+    }
+
+    public synchronized void putResult(AnalyzedProperty property, String result) {
+        this.putResult(property, new StringResult(result, property.getName()));
+    }
+
     public synchronized void putResult(AnalyzedProperty property, List<?> result) {
         this.putResult(property, new ListResult<>(result, property.getName()));
     }
@@ -149,6 +194,10 @@ public class ScanReport extends Observable {
 
     public synchronized void putResult(AnalyzedProperty property, Map<?, ?> result) {
         this.putResult(property, new MapResult<>(result, property.getName()));
+    }
+
+    public synchronized <T> void putResult(AnalyzedProperty property, T result) {
+        this.putResult(property, new ObjectResult<>(result, property.getName()));
     }
 
     public synchronized void removeResult(AnalyzedProperty property) {


### PR DESCRIPTION
tl;dr:

- Added new `ObjectResult` class to store arbitrary results in `ScanReport`
- Added the following subclasses of `ObjectResult` as a shorthand:
  - `BigIntegerResult`
  - `IntegerResult`
  - `LongResult`
  - `StringResult`
- Added corresponding getter and setter overloads to `ScanReport` class