### PR TITLE
feat: Native ScanReport json serialization support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>jcommander</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>

--- a/src/main/java/de/rub/nds/scanner/core/guideline/Guideline.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/Guideline.java
@@ -11,6 +11,8 @@ package de.rub.nds.scanner.core.guideline;
 import de.rub.nds.scanner.core.report.ScanReport;
 import jakarta.xml.bind.annotation.*;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @XmlRootElement(name = "guideline")
@@ -29,7 +31,7 @@ public class Guideline<ReportT extends ScanReport> implements Serializable {
     public Guideline(String name, String link, List<GuidelineCheck<ReportT>> checks) {
         this.name = name;
         this.link = link;
-        this.checks = checks;
+        this.checks = new ArrayList<>(checks);
     }
 
     public String getName() {
@@ -49,10 +51,10 @@ public class Guideline<ReportT extends ScanReport> implements Serializable {
     }
 
     public List<GuidelineCheck<ReportT>> getChecks() {
-        return checks;
+        return Collections.unmodifiableList(checks);
     }
 
-    public void setChecks(List<GuidelineCheck<ReportT>> checks) {
-        this.checks = checks;
+    public void addCheck(GuidelineCheck<ReportT> check) {
+        checks.add(check);
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineAdherence.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineAdherence.java
@@ -12,5 +12,13 @@ public enum GuidelineAdherence {
     ADHERED,
     VIOLATED,
     CONDITION_NOT_MET,
-    CHECK_FAILED
+    CHECK_FAILED;
+
+    /**
+     * @param value evaluation of a boolean to GuidelineAdherence.
+     * @return GuidelineAdherence.ADHERED if true and GuidelineAdherence.VIOLATED if false
+     */
+    public static GuidelineAdherence of(boolean value) {
+        return value ? ADHERED : VIOLATED;
+    }
 }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineAdherence.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineAdherence.java
@@ -1,0 +1,16 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.guideline;
+
+public enum GuidelineAdherence {
+    ADHERED,
+    VIOLATED,
+    CONDITION_NOT_MET,
+    CHECK_FAILED
+}

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheck.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheck.java
@@ -77,8 +77,6 @@ public abstract class GuidelineCheck<ReportT extends ScanReport> {
         return requirementLevel;
     }
 
-    public abstract String getId();
-
     public GuidelineCheckCondition getCondition() {
         return condition;
     }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -12,6 +12,7 @@ import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.result.TestResult;
 import de.rub.nds.scanner.core.probe.result.TestResults;
 import jakarta.xml.bind.annotation.*;
+import java.util.Collections;
 import java.util.List;
 
 @XmlRootElement
@@ -65,23 +66,11 @@ public class GuidelineCheckCondition {
         return result;
     }
 
-    public void setResult(TestResult result) {
-        this.result = result;
-    }
-
     public List<GuidelineCheckCondition> getAnd() {
-        return and;
-    }
-
-    public void setAnd(List<GuidelineCheckCondition> and) {
-        this.and = and;
+        return Collections.unmodifiableList(and);
     }
 
     public List<GuidelineCheckCondition> getOr() {
-        return or;
-    }
-
-    public void setOr(List<GuidelineCheckCondition> or) {
-        this.or = or;
+        return Collections.unmodifiableList(or);
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -67,10 +67,10 @@ public class GuidelineCheckCondition {
     }
 
     public List<GuidelineCheckCondition> getAnd() {
-        return Collections.unmodifiableList(and);
+        return and != null ? Collections.unmodifiableList(and) : null;
     }
 
     public List<GuidelineCheckCondition> getOr() {
-        return Collections.unmodifiableList(or);
+        return or != null ? Collections.unmodifiableList(or) : null;
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckResult.java
@@ -8,54 +8,45 @@
  */
 package de.rub.nds.scanner.core.guideline;
 
-import de.rub.nds.scanner.core.probe.result.TestResult;
-import jakarta.xml.bind.annotation.XmlAnyElement;
+public class GuidelineCheckResult {
 
-public abstract class GuidelineCheckResult {
+    private String checkName;
+    private GuidelineAdherence adherence;
+    private String hint;
 
-    private String id;
-    private String name;
-
-    @XmlAnyElement(lax = true)
-    private TestResult result;
-
-    private GuidelineCheckCondition condition;
-
-    public GuidelineCheckResult(TestResult result) {
-        this.result = result;
+    public GuidelineCheckResult(String checkName, GuidelineAdherence adherence) {
+        this.checkName = checkName;
+        this.adherence = adherence;
+        this.hint = null;
     }
 
-    public abstract String display();
-
-    public final String getId() {
-        return id;
+    public GuidelineCheckResult(String checkName, GuidelineAdherence adherence, String hint) {
+        this.checkName = checkName;
+        this.adherence = adherence;
+        this.hint = hint;
     }
 
-    public final void setId(String id) {
-        this.id = id;
+    public String getCheckName() {
+        return checkName;
     }
 
-    public final String getName() {
-        return name;
+    public void setCheckName(String checkName) {
+        this.checkName = checkName;
     }
 
-    public final void setName(String name) {
-        this.name = name;
+    public GuidelineAdherence getAdherence() {
+        return adherence;
     }
 
-    public final TestResult getResult() {
-        return result;
+    public void setAdherence(GuidelineAdherence adherence) {
+        this.adherence = adherence;
     }
 
-    public final void setResult(TestResult result) {
-        this.result = result;
+    public String getHint() {
+        return hint;
     }
 
-    public GuidelineCheckCondition getCondition() {
-        return condition;
-    }
-
-    public void setCondition(GuidelineCheckCondition condition) {
-        this.condition = condition;
+    public void setHint(String hint) {
+        this.hint = hint;
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineReport.java
@@ -8,47 +8,25 @@
  */
 package de.rub.nds.scanner.core.guideline;
 
-import de.rub.nds.scanner.core.probe.result.TestResults;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
+@JsonIncludeProperties({"name", "link", "results"})
+@JsonPropertyOrder({"name", "link", "results"})
 public class GuidelineReport {
 
     private String name;
     private String link;
-    private List<GuidelineCheckResult> passed;
-    private List<GuidelineCheckResult> failed;
-    private List<GuidelineCheckResult> uncertain;
-    private List<GuidelineCheckResult> skipped;
+    private final List<GuidelineCheckResult> results;
 
     public GuidelineReport(String name, String link, List<GuidelineCheckResult> results) {
         this.name = name;
         this.link = link;
-        this.passed =
-                results.stream()
-                        .filter(result -> Objects.equals(TestResults.TRUE, result.getResult()))
-                        .collect(Collectors.toList());
-        this.failed =
-                results.stream()
-                        .filter(result -> Objects.equals(TestResults.FALSE, result.getResult()))
-                        .collect(Collectors.toList());
-        this.skipped =
-                results.stream()
-                        .filter(
-                                result ->
-                                        Objects.equals(
-                                                TestResults.COULD_NOT_TEST, result.getResult()))
-                        .collect(Collectors.toList());
-        this.uncertain =
-                results.stream()
-                        .filter(result -> !Objects.equals(TestResults.TRUE, result.getResult()))
-                        .filter(result -> !Objects.equals(TestResults.FALSE, result.getResult()))
-                        .filter(
-                                result ->
-                                        !Objects.equals(
-                                                TestResults.COULD_NOT_TEST, result.getResult()))
-                        .collect(Collectors.toList());
+        this.results = new ArrayList<>(results);
     }
 
     public String getName() {
@@ -67,35 +45,35 @@ public class GuidelineReport {
         this.link = link;
     }
 
-    public List<GuidelineCheckResult> getPassed() {
-        return passed;
+    public List<GuidelineCheckResult> getResults() {
+        return Collections.unmodifiableList(results);
     }
 
-    public void setPassed(List<GuidelineCheckResult> passed) {
-        this.passed = passed;
+    public void addResult(GuidelineCheckResult result) {
+        results.add(result);
     }
 
-    public List<GuidelineCheckResult> getFailed() {
-        return failed;
+    public List<GuidelineCheckResult> getAdhered() {
+        return results.stream()
+                .filter(result -> result.getAdherence() == GuidelineAdherence.ADHERED)
+                .collect(Collectors.toUnmodifiableList());
     }
 
-    public void setFailed(List<GuidelineCheckResult> failed) {
-        this.failed = failed;
+    public List<GuidelineCheckResult> getViolated() {
+        return results.stream()
+                .filter(result -> result.getAdherence() == GuidelineAdherence.VIOLATED)
+                .collect(Collectors.toUnmodifiableList());
     }
 
-    public List<GuidelineCheckResult> getUncertain() {
-        return uncertain;
+    public List<GuidelineCheckResult> getConditionNotMet() {
+        return results.stream()
+                .filter(result -> result.getAdherence() == GuidelineAdherence.CONDITION_NOT_MET)
+                .collect(Collectors.toUnmodifiableList());
     }
 
-    public void setUncertain(List<GuidelineCheckResult> uncertain) {
-        this.uncertain = uncertain;
-    }
-
-    public List<GuidelineCheckResult> getSkipped() {
-        return skipped;
-    }
-
-    public void setSkipped(List<GuidelineCheckResult> skipped) {
-        this.skipped = skipped;
+    public List<GuidelineCheckResult> getFailedChecks() {
+        return results.stream()
+                .filter(result -> result.getAdherence() == GuidelineAdherence.CHECK_FAILED)
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/passive/ExtractedValueContainer.java
+++ b/src/main/java/de/rub/nds/scanner/core/passive/ExtractedValueContainer.java
@@ -8,6 +8,7 @@
  */
 package de.rub.nds.scanner.core.passive;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,6 +43,7 @@ public class ExtractedValueContainer<ValueT> {
         return set.size() == extractedValueList.size();
     }
 
+    @JsonValue
     public List<ValueT> getExtractedValueList() {
         return extractedValueList;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/AnalyzedProperty.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/AnalyzedProperty.java
@@ -8,6 +8,7 @@
  */
 package de.rub.nds.scanner.core.probe;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -18,5 +19,6 @@ public interface AnalyzedProperty {
 
     AnalyzedPropertyCategory getCategory();
 
+    @JsonValue
     String getName();
 }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/CollectionResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/CollectionResult.java
@@ -8,6 +8,9 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import java.io.Serializable;
 import java.util.Collection;
@@ -17,6 +20,8 @@ import java.util.Collection;
  *
  * @param <T> the type of which the CollectionResult consists.
  */
+@JsonIncludeProperties({"type", "value"})
+@JsonPropertyOrder({"type", "value"})
 public class CollectionResult<T> implements TestResult, Serializable {
 
     private final AnalyzedProperty property;
@@ -34,6 +39,7 @@ public class CollectionResult<T> implements TestResult, Serializable {
     /**
      * @return the collection of the CollectionResult object of type T.
      */
+    @JsonGetter("value")
     public Collection<T> getCollection() {
         return collection;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
@@ -8,6 +8,9 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import java.io.Serializable;
 import java.util.Map;
@@ -18,6 +21,8 @@ import java.util.Map;
  * @param <S> the key types of the map.
  * @param <T> the value types of the map.
  */
+@JsonIncludeProperties({"type", "value"})
+@JsonPropertyOrder({"type", "value"})
 public class MapResult<S, T> implements TestResult, Serializable {
 
     private final AnalyzedProperty property;
@@ -40,6 +45,7 @@ public class MapResult<S, T> implements TestResult, Serializable {
     /**
      * @return the map of the MapResult object.
      */
+    @JsonProperty("value")
     public Map<S, T> getMap() {
         return map;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/NotApplicableResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/NotApplicableResult.java
@@ -8,9 +8,13 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import java.io.Serializable;
 
+@JsonIncludeProperties({"type", "reason"})
+@JsonPropertyOrder({"type", "reason"})
 public class NotApplicableResult implements TestResult, Serializable {
 
     private final AnalyzedProperty property;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
@@ -8,9 +8,13 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import java.io.Serializable;
 
+@JsonIncludeProperties({"type", "value"})
+@JsonPropertyOrder({"type", "value"})
 public class ObjectResult<T> implements TestResult, Serializable {
 
     private final AnalyzedProperty property;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResult.java
@@ -25,4 +25,8 @@ public interface TestResult {
     default boolean isRealResult() {
         return true;
     }
+
+    default String getType() {
+        return this.getClass().getSimpleName();
+    }
 }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
@@ -8,6 +8,10 @@
  */
 package de.rub.nds.scanner.core.probe.result;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -15,6 +19,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * property.
  */
 @XmlRootElement(name = "result")
+@JsonIncludeProperties({"type", "value"})
+@JsonPropertyOrder({"type", "value"})
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum TestResults implements TestResult {
     TRUE,
     FALSE,
@@ -29,6 +36,7 @@ public enum TestResults implements TestResult {
     TIMEOUT;
 
     @Override
+    @JsonProperty("value")
     public String getName() {
         return name();
     }

--- a/src/main/java/de/rub/nds/scanner/core/report/PerformanceData.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/PerformanceData.java
@@ -16,8 +16,6 @@ public class PerformanceData {
     private long startTime;
     private long stopTime;
 
-    private PerformanceData() {}
-
     public PerformanceData(ProbeType type, long startTime, long stopTime) {
         this.type = type;
         this.startTime = startTime;

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
@@ -8,6 +8,7 @@
  */
 package de.rub.nds.scanner.core.report;
 
+import com.fasterxml.jackson.annotation.*;
 import de.rub.nds.scanner.core.guideline.GuidelineReport;
 import de.rub.nds.scanner.core.passive.ExtractedValueContainer;
 import de.rub.nds.scanner.core.passive.TrackableValue;
@@ -20,9 +21,32 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@JsonIncludeProperties({
+    "results",
+    "extractedValues",
+    "guidelineReports",
+    "scoreReport",
+    "probePerformanceData",
+    "performedConnections",
+    "scanStartTime",
+    "scanEndTime"
+})
+@JsonPropertyOrder({
+    "scanStartTime",
+    "scanEndTime",
+    "performedConnections",
+    "results",
+    "extractedValues",
+    "guidelineReports",
+    "scoreReport",
+    "probePerformanceData"
+})
 public class ScanReport extends Observable {
 
-    private final HashMap<AnalyzedProperty, TestResult> resultMap;
+    @JsonProperty("results")
+    private Map<AnalyzedProperty, TestResult> resultMap;
+
+    @JsonProperty("extractedValues")
     private final Map<TrackableValue, ExtractedValueContainer<?>> extractedValueContainerMap;
 
     private final List<GuidelineReport> guidelineReports;

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReportSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReportSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.report;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** This class serializes a scan report to a JSON file. */
+public class ScanReportSerializer {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final ObjectMapper mapper;
+
+    static {
+        mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        mapper.configOverride(BigDecimal.class)
+                .setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
+    }
+
+    /**
+     * Serializes a scan report to a JSON file.
+     *
+     * @param outputFile The file to write the report to.
+     * @param scanReport The scan report to serialize.
+     */
+    public static void serialize(File outputFile, ScanReport scanReport) {
+        try {
+            mapper.writerWithDefaultPrettyPrinter().writeValue(outputFile, scanReport);
+        } catch (IOException e) {
+            LOGGER.error("Could not serialize scan report", e);
+        }
+    }
+
+    /**
+     * Registers a module with the underlying object mapper.
+     *
+     * @param module The module to register.
+     */
+    public static void registerModuleWithMapper(Module module) {
+        mapper.registerModule(module);
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReportSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReportSerializer.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import de.rub.nds.scanner.core.util.ByteArrayHexSerializer;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -27,6 +29,12 @@ public class ScanReportSerializer {
 
     static {
         mapper = new ObjectMapper();
+
+        SimpleModule builtInModule = new SimpleModule("ScannerCoreBuiltInModule");
+        builtInModule.addKeySerializer(byte[].class, new ByteArrayHexSerializer(true));
+        builtInModule.addSerializer(new ByteArrayHexSerializer(false));
+
+        mapper.registerModule(builtInModule);
         mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.configOverride(BigDecimal.class)
                 .setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
@@ -8,6 +8,7 @@
  */
 package de.rub.nds.scanner.core.report.rating;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.result.TestResult;
 import de.rub.nds.scanner.core.probe.result.TestResults;
@@ -110,6 +111,7 @@ public class PropertyResultRatingInfluencer implements Comparable<PropertyResult
         this.referencedPropertyResult = referencedPropertyResult;
     }
 
+    @JsonIgnore
     public boolean isBadInfluence() {
         return (influence != null && influence < 0 || scoreCap != null);
     }

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/ScoreReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/ScoreReport.java
@@ -9,17 +9,16 @@
 package de.rub.nds.scanner.core.report.rating;
 
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class ScoreReport {
 
     private final int score;
 
-    private final LinkedHashMap<AnalyzedProperty, PropertyResultRatingInfluencer> influencers;
+    private final Map<AnalyzedProperty, PropertyResultRatingInfluencer> influencers;
 
     public ScoreReport(
-            int score,
-            LinkedHashMap<AnalyzedProperty, PropertyResultRatingInfluencer> influencers) {
+            int score, Map<AnalyzedProperty, PropertyResultRatingInfluencer> influencers) {
         this.score = score;
         this.influencers = influencers;
     }
@@ -28,7 +27,7 @@ public class ScoreReport {
         return score;
     }
 
-    public LinkedHashMap<AnalyzedProperty, PropertyResultRatingInfluencer> getInfluencers() {
+    public Map<AnalyzedProperty, PropertyResultRatingInfluencer> getInfluencers() {
         return influencers;
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/util/ByteArrayHexSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/ByteArrayHexSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Scanner Core - A modular framework for probe definition, execution, and result analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * Serializer for byte arrays in key and value positions. The serializer will output the byte array
+ * as a hex string. Behaviour (key or value) can be specified in the constructor.
+ */
+public class ByteArrayHexSerializer extends StdSerializer<byte[]> {
+
+    private final boolean keySerializer;
+
+    /**
+     * Create a new serializer. Behaviour (key or value) can be specified via the keySerializer
+     * parameter.
+     *
+     * @param keySerializer true if the serializer should be used for keys, false if it should be
+     *     used for values
+     */
+    public ByteArrayHexSerializer(boolean keySerializer) {
+        super(byte[].class);
+        this.keySerializer = keySerializer;
+    }
+
+    @Override
+    public void serialize(
+            byte[] bytes, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        if (keySerializer) {
+            jsonGenerator.writeFieldName(bytesToRawHexString(bytes));
+        } else {
+            jsonGenerator.writeString(bytesToRawHexString(bytes));
+        }
+    }
+
+    private static String bytesToRawHexString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/de/rub/nds/scanner/core/util/ComparableByteArray.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/ComparableByteArray.java
@@ -8,11 +8,12 @@
  */
 package de.rub.nds.scanner.core.util;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 
 public class ComparableByteArray {
 
-    private byte[] array;
+    @JsonValue private byte[] array;
 
     public ComparableByteArray(byte[] array) {
         this.array = array;


### PR DESCRIPTION
This PR adds support for serializing objects of ScanReport to JSON without using a custom serializer. This has been achieved by annotating the ScanReport class as well as all referenced classes with Jackson annotations. Note that only serialization (but not deserialization) has been taken care of! A sample scan report can be found below. Extending `ScanReport` in subsequent projects will require additional care to produce meaningful JSON.

In the process I had a more detailed look at the current implementation of the `guideline` package. I made significant changes to the API here, so this isn't a drop-in replacement (and will require changes in subsequent projects). However, I think that these changes will ease the use of guidelines with our scanner. The following changes have been made:

- `GuidelineCheckResult` does no longer store the result as an instance of `TestResult`. Instead, a new enum `GuidelineAdherance` has been introduced with the values `ADHERED`, `VIOLATED`, `CONDITION_NOT_MET`, and `CHECK_FAILED` (replacing the old `TestResults` instances). The old implementation allowed arbritrary test results to be used as a check result (which it shouldn't!) and people may confuse these check results with probe results.
- `GuidelineCheck` no longer have an getId() method. This has been removed in favor of overriding `toString` where necessary. Consequently, `id` has been removed from `GuidelineCheckResult`.
- `GuidelineChecker` no longer inverts the `GuidelineCheckResult` depending on the requirement level. Calling `evaluate` should return the correct value without the need of inverting the result. **This will need adressing in all subclasses of `GuidelineCheckResult`!**
- Most getters now return unmodifiable lists preventing accidental changes to guidelines and / or check results.

<details>
  <summary><h3>Sample ScanReport JSON</h3></summary>

  ```json
  {
    "scanStartTime": 1688573435493,
    "scanEndTime": 1688573435494,
    "performedConnections": 10,
    "results": {
      "TEST_ANALYZED_PROPERTY_LONG": {
        "type": "LongResult",
        "value": 123456
      },
      "TEST_ANALYZED_PROPERTY_OBJECT": {
        "type": "ObjectResult",
        "value": "Object result"
      },
      "TEST_ANALYZED_PROPERTY_SET": {
        "type": "SetResult",
        "value": [
          "Result",
          "Set"
        ]
      },
      "TEST_ANALYZED_PROPERTY_INTEGER": {
        "type": "IntegerResult",
        "value": 123
      },
      "TEST_ANALYZED_PROPERTY_BIGINT": {
        "type": "BigIntegerResult",
        "value": 1234567890
      },
      "TEST_ANALYZED_PROPERTY_NOT_APPLICABLE": {
        "type": "NotApplicableResult",
        "reason": "Not applicable!"
      },
      "TEST_ANALYZED_PROPERTY_STRING": {
        "type": "StringResult",
        "value": "String result"
      },
      "TEST_ANALYZED_PROPERTY_SIMPLE": {
        "type": "TestResults",
        "value": "UNCERTAIN"
      },
      "TEST_ANALYZED_PROPERTY_COLLECTION": {
        "type": "ListResult",
        "value": [
          "Collection",
          "Result"
        ]
      },
      "TEST_ANALYZED_PROPERTY_LIST": {
        "type": "ListResult",
        "value": [
          "List",
          "Result"
        ]
      },
      "TEST_ANALYZED_PROPERTY_MAP": {
        "type": "MapResult",
        "value": {
          "Result": "Map",
          "Map": "Result"
        }
      }
    },
    "extractedValues": {
      "TEST_TRACKABLE_VALUE": [
        "Some",
        "extracted",
        "value"
      ]
    },
    "guidelineReports": [
      {
        "name": "Test guideline",
        "link": "https://example.com",
        "results": [
          {
            "checkName": "TEST_GUIDELINE_CHECK_RESULT",
            "adherence": "VIOLATED",
            "hint": "Some additional hint what went wrong!"
          }
        ]
      }
    ],
    "scoreReport": {
      "score": 100,
      "influencers": {
        "TEST_ANALYZED_PROPERTY_SIMPLE": {
          "result": {
            "type": "TestResults",
            "value": "TRUE"
          },
          "influence": 10,
          "scoreCap": null,
          "referencedProperty": null,
          "referencedPropertyResult": null
        }
      }
    },
    "probePerformanceData": []
  }
  ```
</details>