### PR TITLE
Dry up scanner probe

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -101,7 +101,7 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
     }
 
     private TestResult convertToResult(AnalyzedProperty property, Object result) {
-        // java 17 could use pattern matching :S
+        // TODO: Use pattern matching with java 17(+)
         if (result instanceof TestResult) {
             return (TestResult) result;
         }

--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -59,10 +59,10 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
-    public final void putIfFalse(
+    public final <T> void putIfFalse(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
-            List<?> actualResult,
+            T actualResult,
             String notApplicableReason) {
         putIfEqual(
                 determiningProperty,
@@ -72,101 +72,10 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
                 TestResults.FALSE);
     }
 
-    public final void putIfFalse(
+    public final <T> void putIfTrue(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
-            Map<?, ?> actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Set<?> actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            BigInteger actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Integer actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Long actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            String actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfFalse(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Object actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.FALSE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            List<?> actualResult,
+            T actualResult,
             String notApplicableReason) {
         putIfEqual(
                 determiningProperty,
@@ -176,101 +85,10 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
                 TestResults.TRUE);
     }
 
-    public final void putIfTrue(
+    public final <T> void putIfEqual(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
-            Map<?, ?> actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Set<?> actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            BigInteger actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Integer actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Long actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            String actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfTrue(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Object actualResult,
-            String notApplicableReason) {
-        putIfEqual(
-                determiningProperty,
-                propertyToSet,
-                actualResult,
-                notApplicableReason,
-                TestResults.TRUE);
-    }
-
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            List<?> actualResult,
+            T actualResult,
             String notApplicableReason,
             TestResult expectedValue) {
         if (!propertiesMap.containsKey(determiningProperty)
@@ -282,153 +100,47 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Map<?, ?> actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
+    private TestResult convertToResult(AnalyzedProperty property, Object result) {
+        // java 17 could use pattern matching :S
+        if (result instanceof TestResult) {
+            return (TestResult) result;
         }
+        if (result instanceof String) {
+            return new StringResult(property, (String) result);
+        }
+        if (result instanceof Long) {
+            return new LongResult(property, (Long) result);
+        }
+        if (result instanceof Integer) {
+            return new IntegerResult(property, (Integer) result);
+        }
+        if (result instanceof BigInteger) {
+            return new BigIntegerResult(property, (BigInteger) result);
+        }
+        if (result instanceof Set) {
+            return new SetResult<>(property, (Set<?>) result);
+        }
+        if (result instanceof Map) {
+            return new MapResult<>(property, (Map<?, ?>) result);
+        }
+        if (result instanceof List) {
+            return new ListResult<>(property, (List<?>) result);
+        }
+        return new ObjectResult<>(property, result);
     }
 
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Set<?> actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
+    public final <T> void put(AnalyzedProperty property, T result) {
+        TestResult internalResult = convertToResult(property, result);
 
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            BigInteger actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
-
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Integer actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
-
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Long actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
-
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            String actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
-
-    public final void putIfEqual(
-            AnalyzedProperty determiningProperty,
-            AnalyzedProperty propertyToSet,
-            Object actualResult,
-            String notApplicableReason,
-            TestResult expectedValue) {
-        if (!propertiesMap.containsKey(determiningProperty)
-                || propertiesMap.get(determiningProperty) == null
-                || !propertiesMap.get(determiningProperty).equals(expectedValue)) {
-            put(propertyToSet, new NotApplicableResult(propertyToSet, notApplicableReason));
-        } else {
-            put(propertyToSet, actualResult);
-        }
-    }
-
-    public final void put(AnalyzedProperty property, TestResult result) {
         if (propertiesMap.containsKey(property)) {
-            propertiesMap.replace(property, result);
+            propertiesMap.replace(property, internalResult);
         } else {
             LOGGER.error(
                     "{} was set in {} but had not been registered!",
                     property,
                     getClass().getSimpleName());
-            propertiesMap.put(property, result);
+            propertiesMap.put(property, internalResult);
         }
-    }
-
-    public final void put(AnalyzedProperty property, List<?> result) {
-        put(property, new ListResult<>(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, Map<?, ?> result) {
-        put(property, new MapResult<>(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, Set<?> result) {
-        put(property, new SetResult<>(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, BigInteger result) {
-        put(property, new BigIntegerResult(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, Integer result) {
-        put(property, new IntegerResult(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, Long result) {
-        put(property, new LongResult(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, String result) {
-        put(property, new StringResult(property, result));
-    }
-
-    public final void put(AnalyzedProperty property, Object result) {
-        put(property, new ObjectResult<>(property, result));
     }
 
     protected final <T> void addToList(AnalyzedProperty property, List<T> result) {


### PR DESCRIPTION
Remove the copy+pasted functions and combine them into one generic function.
In the internal put call, we have to distinguish the types again unfortunately (maybe change that in the future and only accept `TestResult`s?)