### PR TITLE
Allow comparing complex results in requirements

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
@@ -42,12 +42,19 @@ public class PropertyValueRequirement<R extends ScanReport>
         }
         Map<AnalyzedProperty, TestResult> propertyMap = report.getResultMap();
         for (AnalyzedProperty property : parameters) {
-            if (!propertyMap.containsKey(property)
-                    || propertyMap.get(property) == null
-                    || !propertyMap.get(property).equals(requiredTestResult)) {
-                checkPropertyValuePair(
-                        property.toString(), propertyMap.get(property), requiredTestResult);
+            if (!propertyMap.containsKey(property)) {
                 return false;
+            }
+            TestResult actualResult = propertyMap.get(property);
+            try {
+                if (actualResult == null
+                        || !actualResult.equalsExpectedResult(requiredTestResult)) {
+                    return false;
+                }
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot evaluate Requirement for Property \"%s\"", property),
+                        e);
             }
         }
         return true;
@@ -55,16 +62,6 @@ public class PropertyValueRequirement<R extends ScanReport>
 
     public TestResult getRequiredTestResult() {
         return requiredTestResult;
-    }
-
-    private void checkPropertyValuePair(
-            String propertyString, TestResult listedResult, TestResult expectedResult) {
-        if (listedResult != null && listedResult.getClass() != expectedResult.getClass()) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Requirement set for property %s expects wrong type of result (found %s but expected %s)",
-                            propertyString, listedResult.getClass(), expectedResult.getClass()));
-        }
     }
 
     @Override

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResult.java
@@ -29,4 +29,33 @@ public interface TestResult {
     default String getType() {
         return this.getClass().getSimpleName();
     }
+
+    /**
+     * Function used to check if the actual result is equal to the expected result. This is used in
+     * the requirement system (cf. {@link
+     * de.rub.nds.scanner.core.probe.requirements.PropertyValueRequirement}). By default, this
+     * function checks if the actual result and the expected result are of the same type and then
+     * uses the default equals implementation. If the types do not match, equals is not called and
+     * an exception is thrown.
+     *
+     * <p>It can be useful to overwrite this to allow a more complex result to evaluate to a simple
+     * result.
+     *
+     * <p>Example: A result might be checked for each version of a protocol. Each of these checks
+     * results in a TestResults enum. The actual result can overwrite this function to say that it
+     * is equal to TRUE if it is TRUE in one version.
+     *
+     * @param expectedResult The expected result stated in the requirement.
+     * @return Whether the actual result is equal to the expected result.
+     */
+    default boolean equalsExpectedResult(TestResult expectedResult) {
+        if (!getClass().equals(expectedResult.getClass())) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot Compare actual result with expected result (type mismatch: found %s but expected %s)"
+                                    + " - Consider overwriting equalsExpectedResult if the type mismatch is intended.",
+                            this.getClass(), expectedResult.getClass()));
+        }
+        return this.equals(expectedResult);
+    }
 }


### PR DESCRIPTION
This allows more complex actual results to compare to a simple expected result. My use case is that I have multiple results (one per protocol version). I require that at least one of them is TRUE. My result class can now implement `equalsExpectedResult` and check whether one of the contained results is equal to the expected results (TRUE)

Also improve error logging by catching exceptions from evaluating the reqirements. Before this, such exceptions would kill the thread.

Also2 if a probe was not executed, set the (unassigned) properties to COULD_NOT_TEST. Or should we use a different enum value here? (NOT_TESTED_YET ?)