### PR TITLE
Handle interrupts instead of ignoring them

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
@@ -12,7 +12,7 @@ import de.rub.nds.scanner.core.report.ScanReport;
 
 public abstract class ScanJobExecutor<ReportT extends ScanReport> {
 
-    public abstract void execute(ReportT report);
+    public abstract void execute(ReportT report) throws InterruptedException;
 
     public abstract void shutdown();
 }


### PR DESCRIPTION
The ScanJobExecutor can now throw an interrupted exception. This is handled in the scanner and the intermediate report is returned.