### PR TITLE
Fix & Improve thread naming

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
@@ -10,23 +10,22 @@ package de.rub.nds.scanner.core.execution;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class NamedThreadFactory implements ThreadFactory {
 
-    private int number;
+    private AtomicInteger number = new AtomicInteger(1);
 
     private final String prefix;
 
     public NamedThreadFactory(String prefix) {
-        this.number = 1;
         this.prefix = prefix;
     }
 
     @Override
     public Thread newThread(Runnable r) {
         Thread newThread = Executors.defaultThreadFactory().newThread(r);
-        newThread.setName(prefix + "-" + number);
-        number++;
+        newThread.setName(prefix + "-" + number.getAndIncrement());
         return newThread;
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
@@ -154,7 +154,7 @@ public abstract class Scanner<
                         executorConfig,
                         scanJob,
                         executorConfig.getParallelProbes(),
-                        "ScannerProbeExecutor")) {
+                        "ScannerProbeExecutor " + report.getRemoteName())) {
             report.setScanStartTime(System.currentTimeMillis());
             scanJobExecutor.execute(report);
         } catch (InterruptedException e) {

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
@@ -70,6 +70,10 @@ public class ScanReport extends Observable {
         unexecutedProbes = new HashSet<>();
     }
 
+    public String getRemoteName() {
+        return "";
+    }
+
     public synchronized Map<AnalyzedProperty, TestResult> getResultMap() {
         return Collections.unmodifiableMap(resultMap);
     }

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
@@ -71,7 +71,7 @@ public class ScanReport extends Observable {
     }
 
     public String getRemoteName() {
-        return "";
+        return "ScanReport.getRemoteName not implemented";
     }
 
     public synchronized Map<AnalyzedProperty, TestResult> getResultMap() {


### PR DESCRIPTION
- Fix NamedThreadFactory having a race condition
- Add info from report to scanner thread name. This way the TLS-Scanner can add the target to the thread name. In the crawler this means we can distinguish the threads from another