### PR TITLE
Fix string concatenation in logger statements

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/ThreadedScanJobExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ThreadedScanJobExecutor.java
@@ -205,7 +205,7 @@ public class ThreadedScanJobExecutor<
             for (ProbeT probe : notScheduledTasks) {
                 if (probe.canBeExecuted(report)) {
                     probe.adjustConfig(report);
-                    LOGGER.debug("Scheduling: " + probe.getProbeName());
+                    LOGGER.debug("Scheduling: {}", probe.getProbeName());
                     Future<ScannerProbe<ReportT, StateT>> future = executor.submit(probe);
                     futureResults.add(future);
                 } else {
@@ -214,7 +214,7 @@ public class ThreadedScanJobExecutor<
             }
             this.notScheduledTasks = newNotSchedulesTasksList;
         } else {
-            LOGGER.error(this.getClass().getName() + " received an update from a non-siteReport");
+            LOGGER.error("{} received an update from a non-siteReport", this.getClass().getName());
         }
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/report/container/KeyValueContainer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/container/KeyValueContainer.java
@@ -47,9 +47,8 @@ public class KeyValueContainer extends ReportContainer {
             return text + " ".repeat(size - text.length());
         } else if (text.length() > size) {
             LOGGER.warn(
-                    "KeyValue 'Key' size is bigger than PADDED_KEY_LENGTH:"
-                            + PADDED_KEY_LENGTH
-                            + " - which breaks the layout. Consider choosing a shorter name or raising PADDED_KEY_LEGNTH");
+                    "KeyValue 'Key' size is bigger than PADDED_KEY_LENGTH:{} - which breaks the layout. Consider choosing a shorter name or raising PADDED_KEY_LEGNTH",
+                    PADDED_KEY_LENGTH);
             return text;
         } else {
             return text;


### PR DESCRIPTION
## Summary
- Replace string concatenation with parameterized logging in ThreadedScanJobExecutor and KeyValueContainer
- Improves performance by avoiding unnecessary string operations when logging is disabled
- Follows best practices for log4j usage

Fixes #80