### PR TITLE
Fix SpotBugs EI_EXPOSE_REP warnings

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/config/ExecutorConfig.java
+++ b/src/main/java/de/rub/nds/scanner/core/config/ExecutorConfig.java
@@ -67,11 +67,11 @@ public final class ExecutorConfig {
     }
 
     public List<ProbeType> getExcludedProbes() {
-        return excludedProbes;
+        return new LinkedList<>(excludedProbes);
     }
 
     public void setExcludedProbes(List<ProbeType> excludedProbes) {
-        this.excludedProbes = excludedProbes;
+        this.excludedProbes = new LinkedList<>(excludedProbes);
     }
 
     public ScannerDetail getScanDetail() {
@@ -107,11 +107,11 @@ public final class ExecutorConfig {
     }
 
     public List<ProbeType> getProbes() {
-        return probes;
+        return probes == null ? null : new LinkedList<>(probes);
     }
 
     public void setProbes(List<ProbeType> probes) {
-        this.probes = probes;
+        this.probes = probes == null ? null : new LinkedList<>(probes);
     }
 
     public void setProbes(ProbeType... probes) {

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
@@ -11,6 +11,7 @@ package de.rub.nds.scanner.core.execution;
 import de.rub.nds.scanner.core.afterprobe.AfterProbe;
 import de.rub.nds.scanner.core.probe.ScannerProbe;
 import de.rub.nds.scanner.core.report.ScanReport;
+import java.util.LinkedList;
 import java.util.List;
 
 public class ScanJob<
@@ -23,15 +24,15 @@ public class ScanJob<
     private final List<AfterProbeT> afterList;
 
     public ScanJob(List<ProbeT> probeList, List<AfterProbeT> afterList) {
-        this.probeList = probeList;
-        this.afterList = afterList;
+        this.probeList = new LinkedList<>(probeList);
+        this.afterList = new LinkedList<>(afterList);
     }
 
     public List<ProbeT> getProbeList() {
-        return probeList;
+        return new LinkedList<>(probeList);
     }
 
     public List<AfterProbeT> getAfterList() {
-        return afterList;
+        return new LinkedList<>(afterList);
     }
 }


### PR DESCRIPTION
## Summary
- Add defensive copying in ExecutorConfig getters and setters for probes and excludedProbes lists
- Add defensive copying in ScanJob constructor and getters for probe and after lists
- Prevents external modification of internal mutable state

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] SpotBugs warnings reduced from 8 to 2 EI_EXPOSE_REP violations
- [x] Code formatting applied successfully

The remaining EI_EXPOSE_REP warnings are in Scanner and ThreadedScanJobExecutor classes where configuration objects are shared by design.