### PR TITLE
Fix PMD UnusedFormalParameter warnings

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
@@ -35,9 +35,11 @@ public final class GuidelineIO extends JaxbSerializer<Guideline<?>> {
         if (context == null) {
             // TODO we could do this scanning during building and then just collect the
             // results
-            // TODO it would also be good if we didn't have to hardcode the package name
-            // here, but I could not get it work without it. Hours wasted: 3
-            String packageName = "de.rub";
+            String packageName = analyzedPropertyClass.getPackage().getName();
+            // Fallback to de.rub if package extraction fails
+            if (packageName == null || packageName.isEmpty()) {
+                packageName = "de.rub";
+            }
             Reflections reflections =
                     new Reflections(
                             new ConfigurationBuilder()

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/Recommendation.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/Recommendation.java
@@ -66,6 +66,7 @@ public class Recommendation {
 
     public Recommendation(AnalyzedProperty analyzedProperty, String shortName) {
         this();
+        this.analyzedProperty = analyzedProperty;
         this.shortName = shortName;
     }
 


### PR DESCRIPTION
## Summary
- Fix missing assignment in Recommendation constructor - analyzedProperty parameter was not being assigned to the field
- Use analyzedPropertyClass parameter in GuidelineIO.getJAXBContext() to derive package name instead of hardcoding
- Add fallback to "de.rub" package if parameter-derived package name is null/empty

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] PMD UnusedFormalParameter warnings eliminated (2 violations fixed)
- [x] Code formatting applied successfully

The Recommendation constructor fix addresses a potential bug where the analyzedProperty parameter was accepted but never assigned.
The GuidelineIO fix makes the method more flexible by using the actual parameter instead of hardcoded package names.