### PR TITLE
Fix remaining PMD violations

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
@@ -46,8 +46,8 @@ public class ProbeTypeConverter implements IStringConverter<ProbeType> {
                 if (convertedType != null) {
                     return convertedType;
                 }
-            } catch (Exception e) {
-                // Ignore
+            } catch (Exception ignored) {
+                // Ignore conversion failures and try next method
             }
         }
         return null;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
@@ -29,7 +29,7 @@ public enum TestResults implements SummarizableTestResult {
     UNASSIGNED_ERROR,
     TIMEOUT;
 
-    private TestResults() {}
+    TestResults() {}
 
     @Override
     public String getName() {

--- a/src/main/java/de/rub/nds/scanner/core/report/AnsiColor.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/AnsiColor.java
@@ -43,7 +43,7 @@ public enum AnsiColor {
 
     static {
         MAP = new HashMap<>();
-        for (AnsiColor c : AnsiColor.values()) {
+        for (AnsiColor c : values()) {
             MAP.put(c.code, c);
         }
     }


### PR DESCRIPTION
## Summary
- Fix EmptyCatchBlock warning in ProbeTypeConverter by renaming exception parameter to 'ignored'
- Remove unnecessary 'private' modifier from enum constructor in TestResults
- Remove unnecessary fully qualified name in AnsiColor static initializer

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] PMD violations fixed: EmptyCatchBlock, UnnecessaryModifier, UnnecessaryFullyQualifiedName
- [x] Code formatting applied successfully

These fixes address minor code style issues and follow PMD best practices for cleaner, more maintainable code.