### PR TITLE
Fix resource leak in Scanner.scan() method

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
@@ -19,6 +19,7 @@ import de.rub.nds.scanner.core.report.rating.ScoreReport;
 import de.rub.nds.scanner.core.report.rating.SiteReportRater;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -194,10 +195,12 @@ public abstract class Scanner<
         // Serialize report to file
         if (executorConfig.isWriteReportToFile()) {
             LOGGER.debug("Writing report to file");
-            try {
-                report.serializeToJson(new FileOutputStream(executorConfig.getOutputFile()));
+            try (FileOutputStream fos = new FileOutputStream(executorConfig.getOutputFile())) {
+                report.serializeToJson(fos);
             } catch (FileNotFoundException e) {
                 throw new RuntimeException("Could not serialize report to file", e);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not write report to file", e);
             }
         }
 


### PR DESCRIPTION
## Summary
- Use try-with-resources for FileOutputStream to ensure proper resource cleanup
- Add IOException catch block for better error handling
- Fixes SpotBugs OBL_UNSATISFIED_OBLIGATION warning about unclosed OutputStream

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] SpotBugs resource leak warning eliminated
- [x] Code formatting applied successfully

This prevents potential file handle leaks when writing scan reports to files and follows Java best practices for resource management.