### PR TITLE
Fix OBL_UNSATISFIED_OBLIGATION SpotBugs issue in JaxbSerializer

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
@@ -90,6 +90,10 @@ public abstract class JaxbSerializer<T> {
         xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         XMLStreamReader xsr = xif.createXMLStreamReader(inputStream);
-        return (T) unmarshaller.unmarshal(xsr);
+        try {
+            return (T) unmarshaller.unmarshal(xsr);
+        } finally {
+            xsr.close();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed resource leak in JaxbSerializer by properly closing XMLStreamReader in read() method