### PR TITLE
Fix EQ_COMPARETO_USE_OBJECT_EQUALS SpotBugs issue

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
@@ -135,6 +135,23 @@ public class PropertyResultRatingInfluencer implements Comparable<PropertyResult
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PropertyResultRatingInfluencer that = (PropertyResultRatingInfluencer) obj;
+        return Objects.equals(scoreCap, that.scoreCap) && Objects.equals(influence, that.influence);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scoreCap, influence);
+    }
+
+    @Override
     public String toString() {
         return "PropertyResultRatingInfluencer{"
                 + "result="


### PR DESCRIPTION
## Summary
- Fixed SpotBugs issue EQ_COMPARETO_USE_OBJECT_EQUALS in PropertyResultRatingInfluencer
- Added equals() and hashCode() methods to maintain consistency with compareTo()