### PR TITLE
Fix BC_BAD_CAST_TO_ABSTRACT_COLLECTION SpotBugs issues

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
@@ -18,21 +18,25 @@ import java.util.List;
  */
 public class ListResult<T> extends CollectionResult<T> {
 
+    private final List<T> list;
+
     @SuppressWarnings("unused")
     // Default constructor for deserialization
     private ListResult() {
         // Default constructor for deserialization
         super(null, null);
+        this.list = null;
     }
 
     public ListResult(AnalyzedProperty property, List<T> list) {
         super(property, list);
+        this.list = list;
     }
 
     /**
      * @return the list of the listResult object.
      */
     public List<T> getList() {
-        return (List<T>) collection;
+        return list;
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
@@ -18,20 +18,24 @@ import java.util.Set;
  */
 public class SetResult<T> extends CollectionResult<T> {
 
+    private final Set<T> set;
+
     @SuppressWarnings("unused")
     private SetResult() {
         // Default constructor for deserialization
         super(null, null);
+        this.set = null;
     }
 
     public SetResult(AnalyzedProperty property, Set<T> set) {
         super(property, set);
+        this.set = set;
     }
 
     /**
      * @return The set of the SetResult.
      */
     public Set<T> getSet() {
-        return (Set<T>) collection;
+        return set;
     }
 }


### PR DESCRIPTION
## Summary
- Fixed unsafe cast from Collection to List in ListResult
- Fixed unsafe cast from Collection to Set in SetResult
- Store specific collection types to ensure type safety