### PR TITLE
Fix DM_DEFAULT_ENCODING SpotBugs issue

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
@@ -12,6 +12,7 @@ import de.rub.nds.protocol.util.SilentByteArrayOutputStream;
 import jakarta.xml.bind.*;
 import jakarta.xml.bind.util.JAXBSource;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -67,7 +68,7 @@ public abstract class JaxbSerializer<T> {
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             transformer.transform(new JAXBSource(context, obj), new StreamResult(tempStream));
             String xmlText = tempStream.toString().replaceAll("\r?\n", System.lineSeparator());
-            outputStream.write(xmlText.getBytes());
+            outputStream.write(xmlText.getBytes(StandardCharsets.UTF_8));
         } catch (TransformerException e) {
             LOGGER.warn(e);
         }


### PR DESCRIPTION
## Summary
- Fixed DM_DEFAULT_ENCODING SpotBugs issue in JaxbSerializer
- Replaced platform-dependent String.getBytes() with explicit UTF-8 encoding using StandardCharsets.UTF_8