### PR TITLE
Fix CT_CONSTRUCTOR_THROW SpotBugs issue

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
@@ -28,34 +28,30 @@ public final class GuidelineIO extends JaxbSerializer<Guideline<?>> {
     public GuidelineIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
             throws JAXBException {
         // analyzedPropertyClass parameter kept for API compatibility
-        this.context = getJAXBContext();
+        super(createJAXBContext());
     }
 
-    private JAXBContext getJAXBContext() throws JAXBException {
-        if (context == null) {
-            // TODO we could do this scanning during building and then just collect the
-            // results
-            // TODO it would also be good if we didn't have to hardcode the package name
-            // here, but I could not get it work without it. Hours wasted: 3
-            String packageName = "de.rub";
-            Reflections reflections =
-                    new Reflections(
-                            new ConfigurationBuilder()
-                                    .setUrls(ClasspathHelper.forPackage(packageName))
-                                    .filterInputsBy(
-                                            new FilterBuilder().includePackage(packageName)));
-            Set<Class<? extends GuidelineCheck>> guidelineCheckClasses =
-                    reflections.getSubTypesOf(GuidelineCheck.class);
-            Set<Class<?>> classes = new HashSet<>();
-            classes.add(Guideline.class);
-            classes.addAll(guidelineCheckClasses);
-            LOGGER.debug("Registering GuidelineClasses in JAXBContext:");
-            for (Class tempClass : classes) {
-                LOGGER.debug(tempClass.getName());
-            }
-            context = JAXBContext.newInstance(classes.toArray(new Class[classes.size()]));
+    private static JAXBContext createJAXBContext() throws JAXBException {
+        // TODO we could do this scanning during building and then just collect the
+        // results
+        // TODO it would also be good if we didn't have to hardcode the package name
+        // here, but I could not get it work without it. Hours wasted: 3
+        String packageName = "de.rub";
+        Reflections reflections =
+                new Reflections(
+                        new ConfigurationBuilder()
+                                .setUrls(ClasspathHelper.forPackage(packageName))
+                                .filterInputsBy(new FilterBuilder().includePackage(packageName)));
+        Set<Class<? extends GuidelineCheck>> guidelineCheckClasses =
+                reflections.getSubTypesOf(GuidelineCheck.class);
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(Guideline.class);
+        classes.addAll(guidelineCheckClasses);
+        Logger logger = LogManager.getLogger();
+        logger.debug("Registering GuidelineClasses in JAXBContext:");
+        for (Class tempClass : classes) {
+            logger.debug(tempClass.getName());
         }
-
-        return context;
+        return JAXBContext.newInstance(classes.toArray(new Class[classes.size()]));
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencersIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencersIO.java
@@ -10,6 +10,7 @@ package de.rub.nds.scanner.core.report.rating;
 
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.util.JaxbSerializer;
+import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import java.util.Set;
 
@@ -17,11 +18,17 @@ public class RatingInfluencersIO extends JaxbSerializer<RatingInfluencers> {
 
     public RatingInfluencersIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
             throws JAXBException {
-        super(
+        super(createContext(analyzedPropertyClass));
+    }
+
+    private static JAXBContext createContext(
+            Class<? extends AnalyzedProperty> analyzedPropertyClass) throws JAXBException {
+        Set<Class<?>> classes =
                 Set.of(
                         RatingInfluencers.class,
                         RatingInfluencer.class,
                         PropertyResultRatingInfluencer.class,
-                        analyzedPropertyClass));
+                        analyzedPropertyClass);
+        return JAXBContext.newInstance(classes.toArray(new Class[0]));
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/RecommendationsIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/RecommendationsIO.java
@@ -10,6 +10,7 @@ package de.rub.nds.scanner.core.report.rating;
 
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.util.JaxbSerializer;
+import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import java.util.Set;
 
@@ -17,11 +18,17 @@ public class RecommendationsIO extends JaxbSerializer<Recommendations> {
 
     public RecommendationsIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
             throws JAXBException {
-        super(
+        super(createContext(analyzedPropertyClass));
+    }
+
+    private static JAXBContext createContext(
+            Class<? extends AnalyzedProperty> analyzedPropertyClass) throws JAXBException {
+        Set<Class<?>> classes =
                 Set.of(
                         Recommendations.class,
                         Recommendation.class,
                         PropertyResultRecommendation.class,
-                        analyzedPropertyClass));
+                        analyzedPropertyClass);
+        return JAXBContext.newInstance(classes.toArray(new Class[0]));
     }
 }

--- a/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
@@ -36,8 +36,8 @@ public abstract class JaxbSerializer<T> {
 
     protected JaxbSerializer() {}
 
-    protected JaxbSerializer(Set<Class<?>> classesToBeBound) throws JAXBException {
-        this.context = getJAXBContext(classesToBeBound);
+    protected JaxbSerializer(JAXBContext context) {
+        this.context = context;
     }
 
     protected synchronized JAXBContext getJAXBContext(Set<Class<?>> classesToBeBound)


### PR DESCRIPTION
## Summary
- Fixed CT_CONSTRUCTOR_THROW SpotBugs warning in JaxbSerializer by refactoring constructor pattern
- Prevents potential finalizer attacks from partially initialized objects