### PR TITLE
Add Javadoc to all public methods in de.rub.nds.scanner.core.execution package

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
@@ -13,8 +13,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * A thread factory that creates threads with custom names.
- * This factory is useful for identifying threads in thread dumps and monitoring tools.
+ * A thread factory that creates threads with custom names. This factory is useful for identifying
+ * threads in thread dumps and monitoring tools.
  */
 public class NamedThreadFactory implements ThreadFactory {
 
@@ -32,8 +32,8 @@ public class NamedThreadFactory implements ThreadFactory {
     }
 
     /**
-     * Creates a new thread with a custom name.
-     * The thread name will be in the format "prefix-number" where number increments for each new thread.
+     * Creates a new thread with a custom name. The thread name will be in the format
+     * "prefix-number" where number increments for each new thread.
      *
      * @param r the runnable to be executed by the new thread
      * @return a newly created thread with a custom name

--- a/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/NamedThreadFactory.java
@@ -12,16 +12,32 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * A thread factory that creates threads with custom names.
+ * This factory is useful for identifying threads in thread dumps and monitoring tools.
+ */
 public class NamedThreadFactory implements ThreadFactory {
 
     private AtomicInteger number = new AtomicInteger(1);
 
     private final String prefix;
 
+    /**
+     * Creates a new NamedThreadFactory with the specified name prefix.
+     *
+     * @param prefix the prefix to use for thread names. Threads will be named as "prefix-number"
+     */
     public NamedThreadFactory(String prefix) {
         this.prefix = prefix;
     }
 
+    /**
+     * Creates a new thread with a custom name.
+     * The thread name will be in the format "prefix-number" where number increments for each new thread.
+     *
+     * @param r the runnable to be executed by the new thread
+     * @return a newly created thread with a custom name
+     */
     @Override
     public Thread newThread(Runnable r) {
         Thread newThread = Executors.defaultThreadFactory().newThread(r);

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
@@ -15,8 +15,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Represents a collection of probes and after-probes to be executed during a scan.
- * A scan job encapsulates the work to be performed as part of a scanning operation.
+ * Represents a collection of probes and after-probes to be executed during a scan. A scan job
+ * encapsulates the work to be performed as part of a scanning operation.
  *
  * @param <ReportT> the type of scan report
  * @param <ProbeT> the type of scanner probe

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJob.java
@@ -14,6 +14,15 @@ import de.rub.nds.scanner.core.report.ScanReport;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Represents a collection of probes and after-probes to be executed during a scan.
+ * A scan job encapsulates the work to be performed as part of a scanning operation.
+ *
+ * @param <ReportT> the type of scan report
+ * @param <ProbeT> the type of scanner probe
+ * @param <AfterProbeT> the type of after-probe
+ * @param <StateT> the type of state object used by probes
+ */
 public class ScanJob<
         ReportT extends ScanReport,
         ProbeT extends ScannerProbe<ReportT, StateT>,
@@ -23,15 +32,31 @@ public class ScanJob<
     private final List<ProbeT> probeList;
     private final List<AfterProbeT> afterList;
 
+    /**
+     * Creates a new scan job with the specified probes and after-probes.
+     *
+     * @param probeList the list of probes to execute
+     * @param afterList the list of after-probes to execute after all probes complete
+     */
     public ScanJob(List<ProbeT> probeList, List<AfterProbeT> afterList) {
         this.probeList = new LinkedList<>(probeList);
         this.afterList = new LinkedList<>(afterList);
     }
 
+    /**
+     * Returns a copy of the probe list.
+     *
+     * @return a new list containing all probes in this scan job
+     */
     public List<ProbeT> getProbeList() {
         return new LinkedList<>(probeList);
     }
 
+    /**
+     * Returns a copy of the after-probe list.
+     *
+     * @return a new list containing all after-probes in this scan job
+     */
     public List<AfterProbeT> getAfterList() {
         return new LinkedList<>(afterList);
     }

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
@@ -11,9 +11,8 @@ package de.rub.nds.scanner.core.execution;
 import de.rub.nds.scanner.core.report.ScanReport;
 
 /**
- * Abstract base class for executing scan jobs.
- * Implementations of this class define specific strategies for executing scan jobs
- * and managing their lifecycle.
+ * Abstract base class for executing scan jobs. Implementations of this class define specific
+ * strategies for executing scan jobs and managing their lifecycle.
  *
  * @param <ReportT> the type of scan report this executor works with
  */
@@ -28,8 +27,8 @@ public abstract class ScanJobExecutor<ReportT extends ScanReport> {
     public abstract void execute(ReportT report) throws InterruptedException;
 
     /**
-     * Shuts down the executor and releases any resources.
-     * This method should be called when the executor is no longer needed.
+     * Shuts down the executor and releases any resources. This method should be called when the
+     * executor is no longer needed.
      */
     public abstract void shutdown();
 }

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScanJobExecutor.java
@@ -10,9 +10,26 @@ package de.rub.nds.scanner.core.execution;
 
 import de.rub.nds.scanner.core.report.ScanReport;
 
+/**
+ * Abstract base class for executing scan jobs.
+ * Implementations of this class define specific strategies for executing scan jobs
+ * and managing their lifecycle.
+ *
+ * @param <ReportT> the type of scan report this executor works with
+ */
 public abstract class ScanJobExecutor<ReportT extends ScanReport> {
 
+    /**
+     * Executes scan jobs and populates the provided report with results.
+     *
+     * @param report the report to populate with scan results
+     * @throws InterruptedException if the execution is interrupted
+     */
     public abstract void execute(ReportT report) throws InterruptedException;
 
+    /**
+     * Shuts down the executor and releases any resources.
+     * This method should be called when the executor is no longer needed.
+     */
     public abstract void shutdown();
 }

--- a/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
@@ -25,6 +25,16 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Abstract base class for implementing scanners.
+ * This class provides the core scanning framework, including probe execution,
+ * report generation, scoring, and guideline evaluation.
+ *
+ * @param <ReportT> the type of scan report
+ * @param <ProbeT> the type of scanner probe
+ * @param <AfterProbeT> the type of after-probe
+ * @param <StateT> the type of state object used by probes
+ */
 public abstract class Scanner<
                 ReportT extends ScanReport,
                 ProbeT extends ScannerProbe<ReportT, StateT>,

--- a/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
@@ -26,9 +26,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Abstract base class for implementing scanners.
- * This class provides the core scanning framework, including probe execution,
- * report generation, scoring, and guideline evaluation.
+ * Abstract base class for implementing scanners. This class provides the core scanning framework,
+ * including probe execution, report generation, scoring, and guideline evaluation.
  *
  * @param <ReportT> the type of scan report
  * @param <ProbeT> the type of scanner probe

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
@@ -75,12 +75,29 @@ public class ScannerThreadPoolExecutor extends ScheduledThreadPoolExecutor {
         return future;
     }
 
+    /**
+     * Submits a Runnable task for execution and returns a Future representing that task.
+     * The task will be automatically cancelled if it exceeds the configured timeout.
+     *
+     * @param <T> the type of the result
+     * @param task the task to submit
+     * @param result the result to return when the task completes
+     * @return a Future representing pending completion of the task
+     */
     public <T> Future<T> submit(Runnable task, T result) {
         Future<T> future = super.submit(task, result);
         cancelFuture(future);
         return future;
     }
 
+    /**
+     * Submits a value-returning task for execution and returns a Future representing the pending results.
+     * The task will be automatically cancelled if it exceeds the configured timeout.
+     *
+     * @param <T> the type of the task's result
+     * @param task the task to submit
+     * @return a Future representing pending completion of the task
+     */
     public <T> Future<T> submit(Callable<T> task) {
         Future<T> future = super.submit(task);
         cancelFuture(future);

--- a/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
@@ -76,8 +76,8 @@ public class ScannerThreadPoolExecutor extends ScheduledThreadPoolExecutor {
     }
 
     /**
-     * Submits a Runnable task for execution and returns a Future representing that task.
-     * The task will be automatically cancelled if it exceeds the configured timeout.
+     * Submits a Runnable task for execution and returns a Future representing that task. The task
+     * will be automatically cancelled if it exceeds the configured timeout.
      *
      * @param <T> the type of the result
      * @param task the task to submit
@@ -91,8 +91,8 @@ public class ScannerThreadPoolExecutor extends ScheduledThreadPoolExecutor {
     }
 
     /**
-     * Submits a value-returning task for execution and returns a Future representing the pending results.
-     * The task will be automatically cancelled if it exceeds the configured timeout.
+     * Submits a value-returning task for execution and returns a Future representing the pending
+     * results. The task will be automatically cancelled if it exceeds the configured timeout.
      *
      * @param <T> the type of the task's result
      * @param task the task to submit

--- a/src/main/java/de/rub/nds/scanner/core/execution/ThreadedScanJobExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ThreadedScanJobExecutor.java
@@ -28,8 +28,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * A threaded implementation of ScanJobExecutor that executes scan probes concurrently.
- * This executor manages probe dependencies, schedules executable probes, and collects results.
+ * A threaded implementation of ScanJobExecutor that executes scan probes concurrently. This
+ * executor manages probe dependencies, schedules executable probes, and collects results.
  *
  * @param <ReportT> the type of scan report
  * @param <ProbeT> the type of scanner probe
@@ -215,8 +215,8 @@ public class ThreadedScanJobExecutor<
     }
 
     /**
-     * Closes this executor by shutting down the underlying thread pool.
-     * This method is called automatically when used in a try-with-resources statement.
+     * Closes this executor by shutting down the underlying thread pool. This method is called
+     * automatically when used in a try-with-resources statement.
      */
     @Override
     public void close() {
@@ -224,8 +224,8 @@ public class ThreadedScanJobExecutor<
     }
 
     /**
-     * Shuts down the underlying thread pool executor.
-     * No new tasks will be accepted after this method is called.
+     * Shuts down the underlying thread pool executor. No new tasks will be accepted after this
+     * method is called.
      */
     @Override
     public void shutdown() {
@@ -233,8 +233,8 @@ public class ThreadedScanJobExecutor<
     }
 
     /**
-     * Handles property change events from the scan report.
-     * When probe support status changes, this method re-evaluates which probes can be executed.
+     * Handles property change events from the scan report. When probe support status changes, this
+     * method re-evaluates which probes can be executed.
      *
      * @param event the property change event
      */
@@ -252,8 +252,9 @@ public class ThreadedScanJobExecutor<
     }
 
     /**
-     * Checks which probes can be executed based on their requirements and schedules them for execution.
-     * This method is called whenever the report state changes to re-evaluate probe eligibility.
+     * Checks which probes can be executed based on their requirements and schedules them for
+     * execution. This method is called whenever the report state changes to re-evaluate probe
+     * eligibility.
      *
      * @param report the current scan report
      */


### PR DESCRIPTION
## Summary
- Added comprehensive Javadoc documentation to all public methods in the `de.rub.nds.scanner.core.execution` package
- Improved code documentation for better maintainability and developer experience
- Each class and public method now has clear documentation explaining its purpose, parameters, and return values