### PR TITLE
Add Javadoc to public methods in guideline package

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/Guideline.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/Guideline.java
@@ -36,26 +36,56 @@ public class Guideline<ReportT extends ScanReport> implements Serializable {
         this.checks = new ArrayList<>(checks);
     }
 
+    /**
+     * Gets the name of this guideline.
+     *
+     * @return the guideline name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of this guideline.
+     *
+     * @param name the guideline name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets the link (URL) to the guideline documentation.
+     *
+     * @return the guideline documentation link
+     */
     public String getLink() {
         return link;
     }
 
+    /**
+     * Sets the link (URL) to the guideline documentation.
+     *
+     * @param link the guideline documentation link to set
+     */
     public void setLink(String link) {
         this.link = link;
     }
 
+    /**
+     * Gets an unmodifiable list of all checks associated with this guideline.
+     *
+     * @return an unmodifiable list of guideline checks
+     */
     public List<GuidelineCheck<ReportT>> getChecks() {
         return Collections.unmodifiableList(checks);
     }
 
+    /**
+     * Adds a new check to this guideline.
+     *
+     * @param check the guideline check to add
+     */
     public void addCheck(GuidelineCheck<ReportT> check) {
         checks.add(check);
     }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheck.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheck.java
@@ -40,8 +40,20 @@ public abstract class GuidelineCheck<ReportT extends ScanReport> {
         this.condition = condition;
     }
 
+    /**
+     * Evaluates this guideline check against the provided report.
+     *
+     * @param report the scan report to evaluate
+     * @return the result of the guideline check evaluation
+     */
     public abstract GuidelineCheckResult evaluate(ReportT report);
 
+    /**
+     * Checks if the report satisfies the condition required for this guideline check.
+     *
+     * @param report the scan report to check against the condition
+     * @return true if the condition is satisfied or no condition is set, false otherwise
+     */
     public boolean passesCondition(ReportT report) {
         return this.passesCondition(report, this.condition);
     }
@@ -71,14 +83,29 @@ public abstract class GuidelineCheck<ReportT extends ScanReport> {
         return false;
     }
 
+    /**
+     * Gets the name of this guideline check.
+     *
+     * @return the check name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the requirement level (e.g., MUST, SHOULD) for this guideline check.
+     *
+     * @return the requirement level
+     */
     public RequirementLevel getRequirementLevel() {
         return requirementLevel;
     }
 
+    /**
+     * Gets the condition that must be satisfied for this check to be applicable.
+     *
+     * @return the condition, or null if no condition is set
+     */
     public GuidelineCheckCondition getCondition() {
         return condition;
     }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -59,7 +59,8 @@ public class GuidelineCheckCondition {
     }
 
     /**
-     * Creates a new condition that requires at least one of the provided conditions to be satisfied.
+     * Creates a new condition that requires at least one of the provided conditions to be
+     * satisfied.
      *
      * @param conditions the list of conditions where at least one must be satisfied
      * @return a new OR condition

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -48,30 +48,67 @@ public class GuidelineCheckCondition {
         this.result = result;
     }
 
+    /**
+     * Creates a new condition that requires all of the provided conditions to be satisfied.
+     *
+     * @param conditions the list of conditions that must all be satisfied
+     * @return a new AND condition
+     */
     public static GuidelineCheckCondition and(List<GuidelineCheckCondition> conditions) {
         return new GuidelineCheckCondition(conditions, null);
     }
 
+    /**
+     * Creates a new condition that requires at least one of the provided conditions to be satisfied.
+     *
+     * @param conditions the list of conditions where at least one must be satisfied
+     * @return a new OR condition
+     */
     public static GuidelineCheckCondition or(List<GuidelineCheckCondition> conditions) {
         return new GuidelineCheckCondition(null, conditions);
     }
 
+    /**
+     * Gets the analyzed property that this condition checks.
+     *
+     * @return the analyzed property
+     */
     public AnalyzedProperty getAnalyzedProperty() {
         return analyzedProperty;
     }
 
+    /**
+     * Sets the analyzed property that this condition checks.
+     *
+     * @param analyzedProperty the analyzed property to set
+     */
     public void setAnalyzedProperty(AnalyzedProperty analyzedProperty) {
         this.analyzedProperty = analyzedProperty;
     }
 
+    /**
+     * Gets the expected test result for the analyzed property.
+     *
+     * @return the expected test result
+     */
     public TestResult getResult() {
         return result;
     }
 
+    /**
+     * Gets the list of conditions that must all be satisfied (AND operation).
+     *
+     * @return an unmodifiable list of AND conditions, or null if this is not an AND condition
+     */
     public List<GuidelineCheckCondition> getAnd() {
         return and != null ? Collections.unmodifiableList(and) : null;
     }
 
+    /**
+     * Gets the list of conditions where at least one must be satisfied (OR operation).
+     *
+     * @return an unmodifiable list of OR conditions, or null if this is not an OR condition
+     */
     public List<GuidelineCheckCondition> getOr() {
         return or != null ? Collections.unmodifiableList(or) : null;
     }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -50,6 +50,7 @@ public class GuidelineCheckCondition {
 
     /**
      * Creates a new condition that requires all of the provided conditions to be satisfied.
+     * Returns true if the list is empty.
      *
      * @param conditions the list of conditions that must all be satisfied
      * @return a new AND condition
@@ -60,9 +61,9 @@ public class GuidelineCheckCondition {
 
     /**
      * Creates a new condition that requires at least one of the provided conditions to be
-     * satisfied.
+     * satisfied. Returns true if the list is empty.
      *
-     * @param conditions the list of conditions where at least one must be satisfied
+     * @param conditions the list of conditions where at least one must be satisfied, or true if the list is empty.
      * @return a new OR condition
      */
     public static GuidelineCheckCondition or(List<GuidelineCheckCondition> conditions) {

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckCondition.java
@@ -49,8 +49,8 @@ public class GuidelineCheckCondition {
     }
 
     /**
-     * Creates a new condition that requires all of the provided conditions to be satisfied.
-     * Returns true if the list is empty.
+     * Creates a new condition that requires all of the provided conditions to be satisfied. Returns
+     * true if the list is empty.
      *
      * @param conditions the list of conditions that must all be satisfied
      * @return a new AND condition
@@ -63,7 +63,8 @@ public class GuidelineCheckCondition {
      * Creates a new condition that requires at least one of the provided conditions to be
      * satisfied. Returns true if the list is empty.
      *
-     * @param conditions the list of conditions where at least one must be satisfied, or true if the list is empty.
+     * @param conditions the list of conditions where at least one must be satisfied, or true if the
+     *     list is empty.
      * @return a new OR condition
      */
     public static GuidelineCheckCondition or(List<GuidelineCheckCondition> conditions) {

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineCheckResult.java
@@ -37,26 +37,56 @@ public abstract class GuidelineCheckResult {
         this.hint = hint;
     }
 
+    /**
+     * Gets the name of the guideline check that produced this result.
+     *
+     * @return the check name
+     */
     public String getCheckName() {
         return checkName;
     }
 
+    /**
+     * Sets the name of the guideline check that produced this result.
+     *
+     * @param checkName the check name to set
+     */
     public void setCheckName(String checkName) {
         this.checkName = checkName;
     }
 
+    /**
+     * Gets the adherence status indicating whether the guideline check passed or failed.
+     *
+     * @return the adherence status
+     */
     public GuidelineAdherence getAdherence() {
         return adherence;
     }
 
+    /**
+     * Sets the adherence status indicating whether the guideline check passed or failed.
+     *
+     * @param adherence the adherence status to set
+     */
     public void setAdherence(GuidelineAdherence adherence) {
         this.adherence = adherence;
     }
 
+    /**
+     * Gets an optional hint providing additional information about the check result.
+     *
+     * @return the hint, or null if no hint is provided
+     */
     public String getHint() {
         return hint;
     }
 
+    /**
+     * Sets an optional hint providing additional information about the check result.
+     *
+     * @param hint the hint to set
+     */
     public void setHint(String hint) {
         this.hint = hint;
     }

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineChecker.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineChecker.java
@@ -24,6 +24,11 @@ public class GuidelineChecker<ReportT extends ScanReport> {
         this.guideline = guideline;
     }
 
+    /**
+     * Evaluates all checks in the guideline against the provided report and adds the results to the report.
+     *
+     * @param report the scan report to evaluate and fill with guideline results
+     */
     public void fillReport(ReportT report) {
         List<GuidelineCheckResult> results = new ArrayList<>();
         for (GuidelineCheck<ReportT> check : guideline.getChecks()) {

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineChecker.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineChecker.java
@@ -25,7 +25,8 @@ public class GuidelineChecker<ReportT extends ScanReport> {
     }
 
     /**
-     * Evaluates all checks in the guideline against the provided report and adds the results to the report.
+     * Evaluates all checks in the guideline against the provided report and adds the results to the
+     * report.
      *
      * @param report the scan report to evaluate and fill with guideline results
      */

--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineReport.java
@@ -37,48 +37,98 @@ public class GuidelineReport {
         this.results = new ArrayList<>(results);
     }
 
+    /**
+     * Gets the name of the guideline that was evaluated.
+     *
+     * @return the guideline name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of the guideline that was evaluated.
+     *
+     * @param name the guideline name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets the link (URL) to the guideline documentation.
+     *
+     * @return the guideline documentation link
+     */
     public String getLink() {
         return link;
     }
 
+    /**
+     * Sets the link (URL) to the guideline documentation.
+     *
+     * @param link the guideline documentation link to set
+     */
     public void setLink(String link) {
         this.link = link;
     }
 
+    /**
+     * Gets an unmodifiable list of all check results for this guideline.
+     *
+     * @return an unmodifiable list of all guideline check results
+     */
     public List<GuidelineCheckResult> getResults() {
         return Collections.unmodifiableList(results);
     }
 
+    /**
+     * Adds a new check result to this guideline report.
+     *
+     * @param result the guideline check result to add
+     */
     public void addResult(GuidelineCheckResult result) {
         results.add(result);
     }
 
+    /**
+     * Gets all check results where the guideline was adhered to.
+     *
+     * @return an unmodifiable list of adhered check results
+     */
     public List<GuidelineCheckResult> getAdhered() {
         return results.stream()
                 .filter(result -> result.getAdherence() == GuidelineAdherence.ADHERED)
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    /**
+     * Gets all check results where the guideline was violated.
+     *
+     * @return an unmodifiable list of violated check results
+     */
     public List<GuidelineCheckResult> getViolated() {
         return results.stream()
                 .filter(result -> result.getAdherence() == GuidelineAdherence.VIOLATED)
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    /**
+     * Gets all check results where the condition for evaluation was not met.
+     *
+     * @return an unmodifiable list of check results with unmet conditions
+     */
     public List<GuidelineCheckResult> getConditionNotMet() {
         return results.stream()
                 .filter(result -> result.getAdherence() == GuidelineAdherence.CONDITION_NOT_MET)
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    /**
+     * Gets all check results where the check evaluation failed with an error.
+     *
+     * @return an unmodifiable list of failed check results
+     */
     public List<GuidelineCheckResult> getFailedChecks() {
         return results.stream()
                 .filter(result -> result.getAdherence() == GuidelineAdherence.CHECK_FAILED)


### PR DESCRIPTION
## Summary
- Added Javadoc comments to all public methods in the `de.rub.nds.scanner.core.guideline` package
- Each class was updated in a separate commit for clarity
- Total of 35 public methods documented across 6 classes