### PR TITLE
Add Javadoc to public methods in probe.requirements package

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
@@ -18,6 +18,11 @@ public final class AndRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final List<Requirement<ReportT>> requirements;
 
+    /**
+     * Constructs a new AndRequirement that evaluates to true when all requirements are satisfied.
+     *
+     * @param requirements the list of requirements (all must be satisfied)
+     */
     public AndRequirement(List<Requirement<ReportT>> requirements) {
         this.requirements = Collections.unmodifiableList(requirements);
     }
@@ -35,11 +40,21 @@ public final class AndRequirement<ReportT extends ScanReport> extends LogicalReq
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    /**
+     * Returns an unmodifiable list of all requirements contained in this AND requirement.
+     *
+     * @return the list of contained requirements
+     */
     @Override
     public List<Requirement<ReportT>> getContainedRequirements() {
         return requirements;
     }
 
+    /**
+     * Returns a string representation of this AND requirement in the format "(req1 and req2 and ...)".
+     *
+     * @return string representation of the AND requirement
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
@@ -51,7 +51,8 @@ public final class AndRequirement<ReportT extends ScanReport> extends LogicalReq
     }
 
     /**
-     * Returns a string representation of this AND requirement in the format "(req1 and req2 and ...)".
+     * Returns a string representation of this AND requirement in the format "(req1 and req2 and
+     * ...)".
      *
      * @return string representation of the AND requirement
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/NotRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/NotRequirement.java
@@ -15,6 +15,11 @@ public final class NotRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final Requirement<ReportT> requirement;
 
+    /**
+     * Constructs a new NotRequirement that negates the evaluation of the given requirement.
+     *
+     * @param requirement the requirement to negate
+     */
     public NotRequirement(Requirement<ReportT> requirement) {
         this.requirement = requirement;
     }
@@ -24,11 +29,21 @@ public final class NotRequirement<ReportT extends ScanReport> extends LogicalReq
         return requirement != null && !requirement.evaluate(report);
     }
 
+    /**
+     * Returns a list containing the single requirement that is being negated.
+     *
+     * @return list containing the negated requirement
+     */
     @Override
     public List<Requirement<ReportT>> getContainedRequirements() {
         return List.of(requirement);
     }
 
+    /**
+     * Returns a string representation of this NOT requirement in the format "not(requirement)".
+     *
+     * @return string representation of the NOT requirement
+     */
     @Override
     public String toString() {
         return String.format("not(%s)", requirement);

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
@@ -18,7 +18,8 @@ public final class OrRequirement<ReportT extends ScanReport> extends LogicalRequ
     private final List<Requirement<ReportT>> requirements;
 
     /**
-     * Constructs a new OrRequirement that evaluates to true when at least one of the requirements is satisfied.
+     * Constructs a new OrRequirement that evaluates to true when at least one of the requirements
+     * is satisfied.
      *
      * @param requirements the list of requirements (at least one must be satisfied)
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
@@ -17,6 +17,11 @@ public final class OrRequirement<ReportT extends ScanReport> extends LogicalRequ
 
     private final List<Requirement<ReportT>> requirements;
 
+    /**
+     * Constructs a new OrRequirement that evaluates to true when at least one of the requirements is satisfied.
+     *
+     * @param requirements the list of requirements (at least one must be satisfied)
+     */
     public OrRequirement(List<Requirement<ReportT>> requirements) {
         this.requirements = Collections.unmodifiableList(requirements);
     }
@@ -26,6 +31,11 @@ public final class OrRequirement<ReportT extends ScanReport> extends LogicalRequ
         return requirements.stream().anyMatch(requirement -> requirement.evaluate(report));
     }
 
+    /**
+     * Returns a string representation of this OR requirement in the format "(req1 or req2 or ...)".
+     *
+     * @return string representation of the OR requirement
+     */
     @Override
     public String toString() {
         return String.format(
@@ -33,6 +43,11 @@ public final class OrRequirement<ReportT extends ScanReport> extends LogicalRequ
                 requirements.stream().map(Object::toString).collect(Collectors.joining(" or ")));
     }
 
+    /**
+     * Returns an unmodifiable list of all requirements contained in this OR requirement.
+     *
+     * @return the list of contained requirements
+     */
     @Override
     public List<Requirement<ReportT>> getContainedRequirements() {
         return requirements;

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
@@ -41,7 +41,8 @@ public abstract class PrimitiveRequirement<ReportT extends ScanReport, Parameter
     }
 
     /**
-     * Returns a string representation of this requirement in the format "ClassName[param1, param2, ...]".
+     * Returns a string representation of this requirement in the format "ClassName[param1, param2,
+     * ...]".
      *
      * @return string representation of the primitive requirement
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
@@ -22,14 +22,29 @@ public abstract class PrimitiveRequirement<ReportT extends ScanReport, Parameter
         extends Requirement<ReportT> {
     protected final List<ParameterT> parameters;
 
+    /**
+     * Constructs a new PrimitiveRequirement with the specified parameters.
+     *
+     * @param parameters the list of parameters for this requirement (made unmodifiable)
+     */
     protected PrimitiveRequirement(List<ParameterT> parameters) {
         this.parameters = Collections.unmodifiableList(parameters);
     }
 
+    /**
+     * Returns an unmodifiable list of parameters for this requirement.
+     *
+     * @return the list of parameters
+     */
     public List<ParameterT> getParameters() {
         return parameters;
     }
 
+    /**
+     * Returns a string representation of this requirement in the format "ClassName[param1, param2, ...]".
+     *
+     * @return string representation of the primitive requirement
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/ProbeRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/ProbeRequirement.java
@@ -17,10 +17,20 @@ import java.util.stream.Collectors;
 public class ProbeRequirement<ReportT extends ScanReport>
         extends PrimitiveRequirement<ReportT, ProbeType> {
 
+    /**
+     * Constructs a new ProbeRequirement that checks if specified probes have been executed.
+     *
+     * @param probes the list of probe types that must have been executed
+     */
     public ProbeRequirement(List<ProbeType> probes) {
         super(probes);
     }
 
+    /**
+     * Constructs a new ProbeRequirement that checks if specified probes have been executed.
+     *
+     * @param probes varargs of probe types that must have been executed
+     */
     public ProbeRequirement(ProbeType... probes) {
         super(List.of(probes));
     }
@@ -38,6 +48,11 @@ public class ProbeRequirement<ReportT extends ScanReport>
         return true;
     }
 
+    /**
+     * Returns a string representation of this requirement listing all required probe types.
+     *
+     * @return string representation in the format "ProbeRequirement[probe1, probe2, ...]"
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
@@ -26,6 +26,9 @@ public class PropertyComparatorRequirement<R extends ScanReport>
     private final Operator operator;
     private final Integer comparisonValue;
 
+    /**
+     * Comparison operators for property size evaluation.
+     */
     public enum Operator {
         GREATER,
         SMALLER,
@@ -71,14 +74,29 @@ public class PropertyComparatorRequirement<R extends ScanReport>
                         operator));
     }
 
+    /**
+     * Returns the comparison operator used in this requirement.
+     *
+     * @return the comparison operator
+     */
     public Operator getOperator() {
         return operator;
     }
 
+    /**
+     * Returns the value against which the property collection size is compared.
+     *
+     * @return the comparison value
+     */
     public Integer getComparisonValue() {
         return comparisonValue;
     }
 
+    /**
+     * Returns a string representation of this requirement in the format "PropertyComparatorRequirement[property operator value]".
+     *
+     * @return string representation of the comparator requirement
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
@@ -26,9 +26,7 @@ public class PropertyComparatorRequirement<R extends ScanReport>
     private final Operator operator;
     private final Integer comparisonValue;
 
-    /**
-     * Comparison operators for property size evaluation.
-     */
+    /** Comparison operators for property size evaluation. */
     public enum Operator {
         GREATER,
         SMALLER,
@@ -93,7 +91,8 @@ public class PropertyComparatorRequirement<R extends ScanReport>
     }
 
     /**
-     * Returns a string representation of this requirement in the format "PropertyComparatorRequirement[property operator value]".
+     * Returns a string representation of this requirement in the format
+     * "PropertyComparatorRequirement[property operator value]".
      *
      * @return string representation of the comparator requirement
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
@@ -19,7 +19,8 @@ import java.util.List;
  */
 public class PropertyFalseRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
     /**
-     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to FALSE.
+     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to
+     * FALSE.
      *
      * @param properties the list of properties that must evaluate to FALSE
      */
@@ -28,7 +29,8 @@ public class PropertyFalseRequirement<R extends ScanReport> extends PropertyValu
     }
 
     /**
-     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to FALSE.
+     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to
+     * FALSE.
      *
      * @param properties varargs of properties that must evaluate to FALSE
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
@@ -18,10 +18,20 @@ import java.util.List;
  * negatively evaluated (TestResults.FALSE).
  */
 public class PropertyFalseRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
+    /**
+     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to FALSE.
+     *
+     * @param properties the list of properties that must evaluate to FALSE
+     */
     public PropertyFalseRequirement(List<AnalyzedProperty> properties) {
         super(TestResults.FALSE, properties);
     }
 
+    /**
+     * Constructs a new PropertyFalseRequirement that checks if the specified properties evaluate to FALSE.
+     *
+     * @param properties varargs of properties that must evaluate to FALSE
+     */
     public PropertyFalseRequirement(AnalyzedProperty... properties) {
         super(TestResults.FALSE, properties);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
@@ -22,7 +22,8 @@ public class PropertyRequirement<R extends ScanReport>
         extends PrimitiveRequirement<R, AnalyzedProperty> {
 
     /**
-     * Constructs a new PropertyRequirement that checks if the specified properties have been evaluated.
+     * Constructs a new PropertyRequirement that checks if the specified properties have been
+     * evaluated.
      *
      * @param properties the list of properties that must be evaluated (not UNASSIGNED_ERROR)
      */
@@ -31,7 +32,8 @@ public class PropertyRequirement<R extends ScanReport>
     }
 
     /**
-     * Constructs a new PropertyRequirement that checks if the specified properties have been evaluated.
+     * Constructs a new PropertyRequirement that checks if the specified properties have been
+     * evaluated.
      *
      * @param properties varargs of properties that must be evaluated (not UNASSIGNED_ERROR)
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
@@ -21,10 +21,20 @@ import java.util.stream.Collectors;
 public class PropertyRequirement<R extends ScanReport>
         extends PrimitiveRequirement<R, AnalyzedProperty> {
 
+    /**
+     * Constructs a new PropertyRequirement that checks if the specified properties have been evaluated.
+     *
+     * @param properties the list of properties that must be evaluated (not UNASSIGNED_ERROR)
+     */
     public PropertyRequirement(List<AnalyzedProperty> properties) {
         super(properties);
     }
 
+    /**
+     * Constructs a new PropertyRequirement that checks if the specified properties have been evaluated.
+     *
+     * @param properties varargs of properties that must be evaluated (not UNASSIGNED_ERROR)
+     */
     public PropertyRequirement(AnalyzedProperty... properties) {
         super(Arrays.asList(properties));
     }
@@ -44,6 +54,11 @@ public class PropertyRequirement<R extends ScanReport>
         return true;
     }
 
+    /**
+     * Returns a string representation of this requirement listing all required properties.
+     *
+     * @return string representation in the format "PropertyRequirement[property1 property2 ...]"
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
@@ -18,10 +18,20 @@ import java.util.List;
  * positively evaluated (TestResults.TRUE).
  */
 public class PropertyTrueRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
+    /**
+     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to TRUE.
+     *
+     * @param properties the list of properties that must evaluate to TRUE
+     */
     public PropertyTrueRequirement(List<AnalyzedProperty> properties) {
         super(TestResults.TRUE, properties);
     }
 
+    /**
+     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to TRUE.
+     *
+     * @param properties varargs of properties that must evaluate to TRUE
+     */
     public PropertyTrueRequirement(AnalyzedProperty... properties) {
         super(TestResults.TRUE, properties);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
@@ -19,7 +19,8 @@ import java.util.List;
  */
 public class PropertyTrueRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
     /**
-     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to TRUE.
+     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to
+     * TRUE.
      *
      * @param properties the list of properties that must evaluate to TRUE
      */
@@ -28,7 +29,8 @@ public class PropertyTrueRequirement<R extends ScanReport> extends PropertyValue
     }
 
     /**
-     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to TRUE.
+     * Constructs a new PropertyTrueRequirement that checks if the specified properties evaluate to
+     * TRUE.
      *
      * @param properties varargs of properties that must evaluate to TRUE
      */

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
@@ -25,7 +25,8 @@ public class PropertyValueRequirement<R extends ScanReport>
     private final TestResult requiredTestResult;
 
     /**
-     * Constructs a new PropertyValueRequirement with the specified expected test result and properties to check.
+     * Constructs a new PropertyValueRequirement with the specified expected test result and
+     * properties to check.
      *
      * @param requiredTestResult the expected test result for all specified properties
      * @param properties the list of properties that must have the expected test result
@@ -37,7 +38,8 @@ public class PropertyValueRequirement<R extends ScanReport>
     }
 
     /**
-     * Constructs a new PropertyValueRequirement with the specified expected test result and properties to check.
+     * Constructs a new PropertyValueRequirement with the specified expected test result and
+     * properties to check.
      *
      * @param requiredTestResult the expected test result for all specified properties
      * @param properties varargs of properties that must have the expected test result
@@ -73,7 +75,8 @@ public class PropertyValueRequirement<R extends ScanReport>
     }
 
     /**
-     * Returns the expected test result that all properties must have for this requirement to be satisfied.
+     * Returns the expected test result that all properties must have for this requirement to be
+     * satisfied.
      *
      * @return the required test result
      */
@@ -82,9 +85,11 @@ public class PropertyValueRequirement<R extends ScanReport>
     }
 
     /**
-     * Returns a string representation of this requirement including the required test result and properties.
+     * Returns a string representation of this requirement including the required test result and
+     * properties.
      *
-     * @return string representation in the format "PropertyValueRequirement[TestResult: property1 property2 ...]"
+     * @return string representation in the format "PropertyValueRequirement[TestResult: property1
+     *     property2 ...]"
      */
     @Override
     public String toString() {

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
@@ -24,12 +24,24 @@ public class PropertyValueRequirement<R extends ScanReport>
 
     private final TestResult requiredTestResult;
 
+    /**
+     * Constructs a new PropertyValueRequirement with the specified expected test result and properties to check.
+     *
+     * @param requiredTestResult the expected test result for all specified properties
+     * @param properties the list of properties that must have the expected test result
+     */
     public PropertyValueRequirement(
             TestResult requiredTestResult, List<AnalyzedProperty> properties) {
         super(properties);
         this.requiredTestResult = requiredTestResult;
     }
 
+    /**
+     * Constructs a new PropertyValueRequirement with the specified expected test result and properties to check.
+     *
+     * @param requiredTestResult the expected test result for all specified properties
+     * @param properties varargs of properties that must have the expected test result
+     */
     public PropertyValueRequirement(TestResult requiredTestResult, AnalyzedProperty... properties) {
         super(List.of(properties));
         this.requiredTestResult = requiredTestResult;
@@ -60,10 +72,20 @@ public class PropertyValueRequirement<R extends ScanReport>
         return true;
     }
 
+    /**
+     * Returns the expected test result that all properties must have for this requirement to be satisfied.
+     *
+     * @return the required test result
+     */
     public TestResult getRequiredTestResult() {
         return requiredTestResult;
     }
 
+    /**
+     * Returns a string representation of this requirement including the required test result and properties.
+     *
+     * @return string representation in the format "PropertyValueRequirement[TestResult: property1 property2 ...]"
+     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
@@ -16,7 +16,8 @@ public final class XorRequirement<ReportT extends ScanReport> extends LogicalReq
     private final Requirement<ReportT> a, b;
 
     /**
-     * Constructs a new XorRequirement that evaluates to true when exactly one of the two requirements is satisfied.
+     * Constructs a new XorRequirement that evaluates to true when exactly one of the two
+     * requirements is satisfied.
      *
      * @param a the first requirement
      * @param b the second requirement

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
@@ -15,6 +15,12 @@ public final class XorRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final Requirement<ReportT> a, b;
 
+    /**
+     * Constructs a new XorRequirement that evaluates to true when exactly one of the two requirements is satisfied.
+     *
+     * @param a the first requirement
+     * @param b the second requirement
+     */
     public XorRequirement(Requirement<ReportT> a, Requirement<ReportT> b) {
         this.a = a;
         this.b = b;
@@ -25,11 +31,21 @@ public final class XorRequirement<ReportT extends ScanReport> extends LogicalReq
         return a.evaluate(report) ^ b.evaluate(report);
     }
 
+    /**
+     * Returns a list containing the two requirements that make up this XOR requirement.
+     *
+     * @return an unmodifiable list containing both requirements
+     */
     @Override
     public List<Requirement<ReportT>> getContainedRequirements() {
         return List.of(a, b);
     }
 
+    /**
+     * Returns a string representation of this XOR requirement in the format "(a xor b)".
+     *
+     * @return string representation of the XOR requirement
+     */
     @Override
     public String toString() {
         return String.format("(%s xor %s)", a, b);


### PR DESCRIPTION
## Summary
- Added Javadoc documentation to all public methods and constructors in the `de.rub.nds.scanner.core.probe.requirements` package
- Documented 31 public methods/constructors across 12 files
- Each file change was committed individually as requested