### PR TITLE
Add Javadoc to all public methods in de.rub.nds.scanner.core.probe package

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/AnalyzedProperty.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/AnalyzedProperty.java
@@ -19,8 +19,18 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface AnalyzedProperty {
 
+    /**
+     * Gets the category of this analyzed property.
+     *
+     * @return the property category
+     */
     AnalyzedPropertyCategory getCategory();
 
+    /**
+     * Gets the name of this analyzed property.
+     *
+     * @return the property name
+     */
     @JsonValue
     String getName();
 }

--- a/src/main/java/de/rub/nds/scanner/core/probe/ProbeType.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ProbeType.java
@@ -15,5 +15,10 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface ProbeType {
+    /**
+     * Gets the name of this probe type.
+     *
+     * @return the name of the probe type
+     */
     String getName();
 }

--- a/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
@@ -20,9 +20,7 @@ public class ProbeTypeConverter implements IStringConverter<ProbeType> {
 
     private Set<Class<? extends ProbeType>> probeTypeClasses;
 
-    /**
-     * Constructs a new ProbeTypeConverter that discovers ProbeType implementations.
-     */
+    /** Constructs a new ProbeTypeConverter that discovers ProbeType implementations. */
     public ProbeTypeConverter() {
         String packageName = "de.rub";
         Reflections reflections =

--- a/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
@@ -20,6 +20,9 @@ public class ProbeTypeConverter implements IStringConverter<ProbeType> {
 
     private Set<Class<? extends ProbeType>> probeTypeClasses;
 
+    /**
+     * Constructs a new ProbeTypeConverter that discovers ProbeType implementations.
+     */
     public ProbeTypeConverter() {
         String packageName = "de.rub";
         Reflections reflections =
@@ -33,6 +36,12 @@ public class ProbeTypeConverter implements IStringConverter<ProbeType> {
                         .collect(Collectors.toSet());
     }
 
+    /**
+     * Converts a string value to a ProbeType instance.
+     *
+     * @param value the string representation of the probe type
+     * @return the converted ProbeType instance, or null if conversion fails
+     */
     @Override
     public ProbeType convert(String value) {
         for (Class<? extends ProbeType> probeTypeClass : probeTypeClasses) {

--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -214,9 +214,7 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
-    /**
-     * Sets all unassigned properties to CANNOT_BE_TESTED status.
-     */
+    /** Sets all unassigned properties to CANNOT_BE_TESTED status. */
     public final void setPropertiesToCannotBeTested() {
         for (AnalyzedProperty property : propertiesMap.keySet()) {
             if (propertiesMap.get(property) == TestResults.UNASSIGNED_ERROR) {

--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -34,10 +34,20 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
     private long startTime;
     private long stopTime;
 
+    /**
+     * Constructs a new ScannerProbe with the specified probe type.
+     *
+     * @param type the type of this probe
+     */
     public ScannerProbe(ProbeType type) {
         this.type = type;
     }
 
+    /**
+     * Executes this probe and returns itself after completion.
+     *
+     * @return this probe instance after execution
+     */
     @Override
     public ScannerProbe<ReportT, StateT> call() {
         LOGGER.debug("Executing: {}", getProbeName());
@@ -49,6 +59,12 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         return this;
     }
 
+    /**
+     * Determines whether this probe can be executed based on the requirements evaluation.
+     *
+     * @param report the report to evaluate requirements against
+     * @return true if the probe can be executed, false otherwise
+     */
     public final boolean canBeExecuted(ReportT report) {
         try {
             return getRequirements().evaluate(report);
@@ -68,6 +84,15 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
+    /**
+     * Sets a property value if the determining property is FALSE.
+     *
+     * @param determiningProperty the property to check
+     * @param propertyToSet the property to set
+     * @param actualResult the result to set if condition is met
+     * @param notApplicableReason reason to provide if condition is not met
+     * @param <T> the type of the actual result
+     */
     public final <T> void putIfFalse(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
@@ -81,6 +106,15 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
                 TestResults.FALSE);
     }
 
+    /**
+     * Sets a property value if the determining property is TRUE.
+     *
+     * @param determiningProperty the property to check
+     * @param propertyToSet the property to set
+     * @param actualResult the result to set if condition is met
+     * @param notApplicableReason reason to provide if condition is not met
+     * @param <T> the type of the actual result
+     */
     public final <T> void putIfTrue(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
@@ -94,6 +128,16 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
                 TestResults.TRUE);
     }
 
+    /**
+     * Sets a property value if the determining property equals the expected value.
+     *
+     * @param determiningProperty the property to check
+     * @param propertyToSet the property to set
+     * @param actualResult the result to set if condition is met
+     * @param notApplicableReason reason to provide if condition is not met
+     * @param expectedValue the expected value to compare against
+     * @param <T> the type of the actual result
+     */
     public final <T> void putIfEqual(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,
@@ -124,6 +168,13 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         };
     }
 
+    /**
+     * Sets a property to the specified result value.
+     *
+     * @param property the property to set
+     * @param result the result value to set
+     * @param <T> the type of the result
+     */
     public final <T> void put(AnalyzedProperty property, T result) {
         TestResult internalResult = convertToResult(property, result);
 
@@ -163,6 +214,9 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
+    /**
+     * Sets all unassigned properties to CANNOT_BE_TESTED status.
+     */
     public final void setPropertiesToCannotBeTested() {
         for (AnalyzedProperty property : propertiesMap.keySet()) {
             if (propertiesMap.get(property) == TestResults.UNASSIGNED_ERROR) {
@@ -171,6 +225,11 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
+    /**
+     * Merges the results of this probe into the provided report.
+     *
+     * @param report the report to merge results into
+     */
     public final void merge(ReportT report) {
         if (getStartTime() != 0 && getStopTime() != 0) {
             report.recordProbePerformance(
@@ -202,34 +261,74 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
+    /**
+     * Gets the requirements that must be satisfied for this probe to execute.
+     *
+     * @return the requirements for this probe
+     */
     public abstract Requirement<ReportT> getRequirements();
 
+    /**
+     * Adjusts the configuration based on the provided report.
+     *
+     * @param report the report used to adjust the configuration
+     */
     public abstract void adjustConfig(ReportT report);
 
     protected abstract void executeTest();
 
     protected abstract void mergeData(ReportT report);
 
+    /**
+     * Gets the type of this probe.
+     *
+     * @return the probe type
+     */
     public ProbeType getType() {
         return type;
     }
 
+    /**
+     * Gets the start time of the probe execution in milliseconds.
+     *
+     * @return the start time
+     */
     public long getStartTime() {
         return startTime;
     }
 
+    /**
+     * Gets the stop time of the probe execution in milliseconds.
+     *
+     * @return the stop time
+     */
     public long getStopTime() {
         return stopTime;
     }
 
+    /**
+     * Gets the name of this probe.
+     *
+     * @return the probe name
+     */
     public String getProbeName() {
         return getType().getName();
     }
 
+    /**
+     * Gets the stats writer associated with this probe.
+     *
+     * @return the stats writer
+     */
     public StatsWriter<StateT> getWriter() {
         return writer;
     }
 
+    /**
+     * Sets the stats writer for this probe.
+     *
+     * @param writer the stats writer to set
+     */
     public void setWriter(StatsWriter<StateT> writer) {
         this.writer = writer;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/AndRequirement.java
@@ -18,6 +18,11 @@ public final class AndRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final List<Requirement<ReportT>> requirements;
 
+    /**
+     * Constructs a new AndRequirement with the specified list of requirements.
+     *
+     * @param requirements the requirements to combine with AND logic
+     */
     public AndRequirement(List<Requirement<ReportT>> requirements) {
         this.requirements = Collections.unmodifiableList(requirements);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/NotRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/NotRequirement.java
@@ -15,6 +15,11 @@ public final class NotRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final Requirement<ReportT> requirement;
 
+    /**
+     * Constructs a new NotRequirement that negates the specified requirement.
+     *
+     * @param requirement the requirement to negate
+     */
     public NotRequirement(Requirement<ReportT> requirement) {
         this.requirement = requirement;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/OrRequirement.java
@@ -17,6 +17,11 @@ public final class OrRequirement<ReportT extends ScanReport> extends LogicalRequ
 
     private final List<Requirement<ReportT>> requirements;
 
+    /**
+     * Constructs a new OrRequirement with the specified list of requirements.
+     *
+     * @param requirements the requirements to combine with OR logic
+     */
     public OrRequirement(List<Requirement<ReportT>> requirements) {
         this.requirements = Collections.unmodifiableList(requirements);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PrimitiveRequirement.java
@@ -26,6 +26,11 @@ public abstract class PrimitiveRequirement<ReportT extends ScanReport, Parameter
         this.parameters = Collections.unmodifiableList(parameters);
     }
 
+    /**
+     * Gets the parameters associated with this requirement.
+     *
+     * @return an unmodifiable list of parameters
+     */
     public List<ParameterT> getParameters() {
         return parameters;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/ProbeRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/ProbeRequirement.java
@@ -17,10 +17,20 @@ import java.util.stream.Collectors;
 public class ProbeRequirement<ReportT extends ScanReport>
         extends PrimitiveRequirement<ReportT, ProbeType> {
 
+    /**
+     * Constructs a new ProbeRequirement with the specified list of probe types.
+     *
+     * @param probes the probe types that must be executed
+     */
     public ProbeRequirement(List<ProbeType> probes) {
         super(probes);
     }
 
+    /**
+     * Constructs a new ProbeRequirement with the specified probe types.
+     *
+     * @param probes the probe types that must be executed
+     */
     public ProbeRequirement(ProbeType... probes) {
         super(List.of(probes));
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyComparatorRequirement.java
@@ -71,10 +71,20 @@ public class PropertyComparatorRequirement<R extends ScanReport>
                         operator));
     }
 
+    /**
+     * Gets the comparison operator used in this requirement.
+     *
+     * @return the operator
+     */
     public Operator getOperator() {
         return operator;
     }
 
+    /**
+     * Gets the value to compare against.
+     *
+     * @return the comparison value
+     */
     public Integer getComparisonValue() {
         return comparisonValue;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyFalseRequirement.java
@@ -18,10 +18,20 @@ import java.util.List;
  * negatively evaluated (TestResults.FALSE).
  */
 public class PropertyFalseRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
+    /**
+     * Constructs a new PropertyFalseRequirement with the specified list of properties.
+     *
+     * @param properties the properties that must evaluate to FALSE
+     */
     public PropertyFalseRequirement(List<AnalyzedProperty> properties) {
         super(TestResults.FALSE, properties);
     }
 
+    /**
+     * Constructs a new PropertyFalseRequirement with the specified properties.
+     *
+     * @param properties the properties that must evaluate to FALSE
+     */
     public PropertyFalseRequirement(AnalyzedProperty... properties) {
         super(TestResults.FALSE, properties);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyRequirement.java
@@ -21,10 +21,20 @@ import java.util.stream.Collectors;
 public class PropertyRequirement<R extends ScanReport>
         extends PrimitiveRequirement<R, AnalyzedProperty> {
 
+    /**
+     * Constructs a new PropertyRequirement with the specified list of properties.
+     *
+     * @param properties the properties that must be evaluated
+     */
     public PropertyRequirement(List<AnalyzedProperty> properties) {
         super(properties);
     }
 
+    /**
+     * Constructs a new PropertyRequirement with the specified properties.
+     *
+     * @param properties the properties that must be evaluated
+     */
     public PropertyRequirement(AnalyzedProperty... properties) {
         super(Arrays.asList(properties));
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyTrueRequirement.java
@@ -18,10 +18,20 @@ import java.util.List;
  * positively evaluated (TestResults.TRUE).
  */
 public class PropertyTrueRequirement<R extends ScanReport> extends PropertyValueRequirement<R> {
+    /**
+     * Constructs a new PropertyTrueRequirement with the specified list of properties.
+     *
+     * @param properties the properties that must evaluate to TRUE
+     */
     public PropertyTrueRequirement(List<AnalyzedProperty> properties) {
         super(TestResults.TRUE, properties);
     }
 
+    /**
+     * Constructs a new PropertyTrueRequirement with the specified properties.
+     *
+     * @param properties the properties that must evaluate to TRUE
+     */
     public PropertyTrueRequirement(AnalyzedProperty... properties) {
         super(TestResults.TRUE, properties);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/PropertyValueRequirement.java
@@ -24,12 +24,24 @@ public class PropertyValueRequirement<R extends ScanReport>
 
     private final TestResult requiredTestResult;
 
+    /**
+     * Constructs a new PropertyValueRequirement with the specified required result and properties.
+     *
+     * @param requiredTestResult the expected test result value
+     * @param properties the properties to check
+     */
     public PropertyValueRequirement(
             TestResult requiredTestResult, List<AnalyzedProperty> properties) {
         super(properties);
         this.requiredTestResult = requiredTestResult;
     }
 
+    /**
+     * Constructs a new PropertyValueRequirement with the specified required result and properties.
+     *
+     * @param requiredTestResult the expected test result value
+     * @param properties the properties to check
+     */
     public PropertyValueRequirement(TestResult requiredTestResult, AnalyzedProperty... properties) {
         super(List.of(properties));
         this.requiredTestResult = requiredTestResult;
@@ -60,6 +72,11 @@ public class PropertyValueRequirement<R extends ScanReport>
         return true;
     }
 
+    /**
+     * Gets the required test result value for this requirement.
+     *
+     * @return the required test result
+     */
     public TestResult getRequiredTestResult() {
         return requiredTestResult;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/requirements/XorRequirement.java
@@ -15,6 +15,12 @@ public final class XorRequirement<ReportT extends ScanReport> extends LogicalReq
 
     private final Requirement<ReportT> a, b;
 
+    /**
+     * Constructs a new XorRequirement with two requirements combined with XOR logic.
+     *
+     * @param a the first requirement
+     * @param b the second requirement
+     */
     public XorRequirement(Requirement<ReportT> a, Requirement<ReportT> b) {
         this.a = a;
         this.b = b;

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/BigIntegerResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/BigIntegerResult.java
@@ -19,6 +19,12 @@ public class BigIntegerResult extends ObjectResult<BigInteger> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new BigIntegerResult with the specified property and value.
+     *
+     * @param property the analyzed property
+     * @param value the BigInteger value
+     */
     public BigIntegerResult(AnalyzedProperty property, BigInteger value) {
         super(property, value);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/CollectionResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/CollectionResult.java
@@ -39,11 +39,22 @@ public class CollectionResult<T> implements TestResult {
         this.collection = null;
     }
 
+    /**
+     * Constructs a new CollectionResult with the specified property and collection.
+     *
+     * @param property the analyzed property
+     * @param collection the collection of values
+     */
     public CollectionResult(AnalyzedProperty property, Collection<T> collection) {
         this.property = property;
         this.collection = collection;
     }
 
+    /**
+     * Gets the analyzed property associated with this result.
+     *
+     * @return the analyzed property
+     */
     public AnalyzedProperty getProperty() {
         return property;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/DetailedResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/DetailedResult.java
@@ -18,18 +18,44 @@ public class DetailedResult<T extends Serializable> implements SummarizableTestR
         this(null, null);
     }
 
+    /**
+     * Creates a DetailedResult with TRUE summary and no details.
+     *
+     * @param <T> the type of details
+     * @return a DetailedResult with TRUE summary
+     */
     public static <T extends Serializable> DetailedResult<T> TRUE() {
         return new DetailedResult<>(TestResults.TRUE);
     }
 
+    /**
+     * Creates a DetailedResult with TRUE summary and specified details.
+     *
+     * @param details the details to include
+     * @param <T> the type of details
+     * @return a DetailedResult with TRUE summary and details
+     */
     public static <T extends Serializable> DetailedResult<T> TRUE(T details) {
         return new DetailedResult<>(TestResults.TRUE, details);
     }
 
+    /**
+     * Creates a DetailedResult with FALSE summary and no details.
+     *
+     * @param <T> the type of details
+     * @return a DetailedResult with FALSE summary
+     */
     public static <T extends Serializable> DetailedResult<T> FALSE() {
         return new DetailedResult<>(TestResults.FALSE);
     }
 
+    /**
+     * Creates a DetailedResult with FALSE summary and specified details.
+     *
+     * @param details the details to include
+     * @param <T> the type of details
+     * @return a DetailedResult with FALSE summary and details
+     */
     public static <T extends Serializable> DetailedResult<T> FALSE(T details) {
         return new DetailedResult<>(TestResults.FALSE, details);
     }
@@ -37,15 +63,31 @@ public class DetailedResult<T extends Serializable> implements SummarizableTestR
     private final T details;
     private final TestResults summary;
 
+    /**
+     * Constructs a new DetailedResult with the specified summary and details.
+     *
+     * @param summary the test result summary
+     * @param details the additional details
+     */
     public DetailedResult(TestResults summary, T details) {
         this.details = details;
         this.summary = summary;
     }
 
+    /**
+     * Constructs a new DetailedResult with the specified summary and no details.
+     *
+     * @param summary the test result summary
+     */
     public DetailedResult(TestResults summary) {
         this(summary, null);
     }
 
+    /**
+     * Gets the details associated with this result.
+     *
+     * @return the details, may be null
+     */
     public T getDetails() {
         return details;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/IntegerResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/IntegerResult.java
@@ -18,6 +18,12 @@ public class IntegerResult extends ObjectResult<Integer> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new IntegerResult with the specified property and value.
+     *
+     * @param property the analyzed property
+     * @param value the Integer value
+     */
     public IntegerResult(AnalyzedProperty property, Integer value) {
         super(property, value);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ListResult.java
@@ -25,6 +25,12 @@ public class ListResult<T> extends CollectionResult<T> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new ListResult with the specified property and list.
+     *
+     * @param property the analyzed property
+     * @param list the list of values
+     */
     public ListResult(AnalyzedProperty property, List<T> list) {
         super(property, list);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/LongResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/LongResult.java
@@ -18,6 +18,12 @@ public class LongResult extends ObjectResult<Long> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new LongResult with the specified property and value.
+     *
+     * @param property the analyzed property
+     * @param value the Long value
+     */
     public LongResult(AnalyzedProperty property, Long value) {
         super(property, value);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/MapResult.java
@@ -34,11 +34,22 @@ public class MapResult<S, T> implements TestResult {
         this.map = null;
     }
 
+    /**
+     * Constructs a new MapResult with the specified property and map.
+     *
+     * @param property the analyzed property
+     * @param map the map of key-value pairs
+     */
     public MapResult(AnalyzedProperty property, Map<S, T> map) {
         this.property = property;
         this.map = map;
     }
 
+    /**
+     * Gets the analyzed property associated with this result.
+     *
+     * @return the analyzed property
+     */
     public AnalyzedProperty getProperty() {
         return property;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/NotApplicableResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/NotApplicableResult.java
@@ -26,6 +26,12 @@ public class NotApplicableResult implements TestResult {
         this.reason = null;
     }
 
+    /**
+     * Constructs a new NotApplicableResult with the specified property and reason.
+     *
+     * @param property the analyzed property
+     * @param reason the reason why the test is not applicable
+     */
     public NotApplicableResult(AnalyzedProperty property, String reason) {
         this.property = property;
         this.reason = reason;
@@ -41,6 +47,11 @@ public class NotApplicableResult implements TestResult {
         return false;
     }
 
+    /**
+     * Gets the reason why the test is not applicable.
+     *
+     * @return the reason
+     */
     public String getReason() {
         return reason;
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/ObjectResult.java
@@ -26,19 +26,42 @@ public class ObjectResult<T> implements TestResult {
         this.value = null;
     }
 
+    /**
+     * Constructs a new ObjectResult with the specified property and value.
+     *
+     * @param property the analyzed property
+     * @param value the result value
+     */
     public ObjectResult(AnalyzedProperty property, T value) {
         this.property = property;
         this.value = value;
     }
 
+    /**
+     * Gets the value of this result.
+     *
+     * @return the result value
+     */
     public T getValue() {
         return value;
     }
 
+    /**
+     * Gets the analyzed property associated with this result.
+     *
+     * @return the analyzed property
+     */
     public AnalyzedProperty getProperty() {
         return property;
     }
 
+    /**
+     * Gets the value cast to the specified class type.
+     *
+     * @param valueClass the class to cast the value to
+     * @param <S> the target type
+     * @return the value cast to the specified type
+     */
     public <S> S getValue(Class<S> valueClass) {
         return valueClass.cast(value);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/SetResult.java
@@ -24,6 +24,12 @@ public class SetResult<T> extends CollectionResult<T> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new SetResult with the specified property and set.
+     *
+     * @param property the analyzed property
+     * @param set the set of values
+     */
     public SetResult(AnalyzedProperty property, Set<T> set) {
         super(property, set);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/StringResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/StringResult.java
@@ -18,6 +18,12 @@ public class StringResult extends ObjectResult<String> {
         super(null, null);
     }
 
+    /**
+     * Constructs a new StringResult with the specified property and value.
+     *
+     * @param property the analyzed property
+     * @param value the String value
+     */
     public StringResult(AnalyzedProperty property, String value) {
         super(property, value);
     }

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/SummarizableTestResult.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/SummarizableTestResult.java
@@ -14,6 +14,11 @@ package de.rub.nds.scanner.core.probe.result;
  * error)
  */
 public interface SummarizableTestResult extends TestResult {
+    /**
+     * Gets the summarized test result.
+     *
+     * @return the summarized result
+     */
     TestResults getSummarizedResult();
 
     /**


### PR DESCRIPTION
## Summary
- Added Javadoc documentation to all public methods in the de.rub.nds.scanner.core.probe package
- Includes documentation for classes in the main package, result subpackage, and requirements subpackage
- Each file was committed separately for better tracking