### PR TITLE
Fix raw type usage warnings in GuidelineIO

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
@@ -31,6 +31,7 @@ public final class GuidelineIO extends JaxbSerializer<Guideline<?>> {
         this.context = getJAXBContext();
     }
 
+    @SuppressWarnings("unchecked")
     private JAXBContext getJAXBContext() throws JAXBException {
         if (context == null) {
             // TODO we could do this scanning during building and then just collect the
@@ -44,13 +45,14 @@ public final class GuidelineIO extends JaxbSerializer<Guideline<?>> {
                                     .setUrls(ClasspathHelper.forPackage(packageName))
                                     .filterInputsBy(
                                             new FilterBuilder().includePackage(packageName)));
+            @SuppressWarnings("rawtypes")
             Set<Class<? extends GuidelineCheck>> guidelineCheckClasses =
                     reflections.getSubTypesOf(GuidelineCheck.class);
             Set<Class<?>> classes = new HashSet<>();
             classes.add(Guideline.class);
             classes.addAll(guidelineCheckClasses);
             LOGGER.debug("Registering GuidelineClasses in JAXBContext:");
-            for (Class tempClass : classes) {
+            for (Class<?> tempClass : classes) {
                 LOGGER.debug(tempClass.getName());
             }
             context = JAXBContext.newInstance(classes.toArray(new Class[classes.size()]));


### PR DESCRIPTION
## Summary
- Fixed raw type usage warnings in GuidelineIO.java by adding appropriate @SuppressWarnings annotations
- Addresses compiler warnings on lines 47 and 53 (now lines 49 and 55 after formatting)
- No functional changes - only eliminates compiler warnings

## Details
The reflections library's `getSubTypesOf` method doesn't handle wildcard generics well, so @SuppressWarnings annotations were added to suppress the raw type warnings while maintaining type safety where possible.

## Test plan
- [x] Code compiles without errors
- [x] Existing tests pass (GuidelineIOTest)
- [x] Code formatting checked with spotless
- [x] No functional changes - only warning suppression