### PR TITLE
Make methods static as identified by static analysis

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -109,7 +109,7 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
-    private TestResult convertToResult(AnalyzedProperty property, Object result) {
+    private static TestResult convertToResult(AnalyzedProperty property, Object result) {
         return switch (result) {
             case null -> new ObjectResult<>(property, null);
             case TestResult testResult -> testResult;

--- a/src/main/java/de/rub/nds/scanner/core/report/container/HeadlineContainer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/container/HeadlineContainer.java
@@ -45,7 +45,7 @@ public class HeadlineContainer extends ReportContainer {
         builder.append("\n");
     }
 
-    private AnsiColor getColorByDepth(int depth) {
+    private static AnsiColor getColorByDepth(int depth) {
         switch (depth) {
             case 0:
                 return AnsiColor.PURPLE;
@@ -64,7 +64,7 @@ public class HeadlineContainer extends ReportContainer {
         return headline;
     }
 
-    private void addHLine(StringBuilder builder) {
+    private static void addHLine(StringBuilder builder) {
         builder.append("-".repeat(Math.max(0, NUMBER_OF_DASHES_IN_H_LINE)));
         builder.append("\n");
     }

--- a/src/main/java/de/rub/nds/scanner/core/report/container/KeyValueContainer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/container/KeyValueContainer.java
@@ -42,7 +42,7 @@ public class KeyValueContainer extends ReportContainer {
         builder.append("\n");
     }
 
-    private String pad(String text, int size) {
+    private static String pad(String text, int size) {
         if (text == null) {
             text = "";
         }

--- a/src/main/java/de/rub/nds/scanner/core/report/container/TableContainer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/container/TableContainer.java
@@ -78,7 +78,7 @@ public class TableContainer extends ReportContainer {
         return paddings;
     }
 
-    private void pad(StringBuilder builder, int n) {
+    private static void pad(StringBuilder builder, int n) {
         builder.append(" ".repeat(Math.max(0, n)));
     }
 

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/SiteReportRater.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/SiteReportRater.java
@@ -62,7 +62,7 @@ public class SiteReportRater {
         return new ScoreReport(score, ratingInfluencers);
     }
 
-    private int computeScore(
+    private static int computeScore(
             HashMap<AnalyzedProperty, PropertyResultRatingInfluencer> influencers) {
         int score = 0;
         for (PropertyResultRatingInfluencer influencer : influencers.values()) {


### PR DESCRIPTION
## Summary
- Made 6 methods static that don't use instance variables
- Addresses static analysis findings for better code quality
- All tests pass, code compiles successfully

## Changes Made
This PR makes the following methods static as they don't access any instance fields:

1. `SiteReportRater.computeScore()` - Calculates score based on parameters only
2. `HeadlineContainer.getColorByDepth()` - Returns color based on depth parameter
3. `HeadlineContainer.addHLine()` - Adds horizontal line to StringBuilder
4. `KeyValueContainer.pad()` - Pads string to specified length
5. `TableContainer.pad()` - Pads StringBuilder with spaces
6. `ScannerProbe.convertToResult()` - Converts objects to TestResult instances

## Test Plan
- [x] Code compiles successfully (`mvn compile`)
- [x] All tests pass (`mvn test`)
- [x] Code formatting applied (`mvn spotless:apply`)