### PR TITLE
Remove unused ThreadPoolExecutor import

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/ScannerThreadPoolExecutor.java
@@ -14,7 +14,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
## Summary
- Removed unused import `java.util.concurrent.ThreadPoolExecutor` from ScannerThreadPoolExecutor.java
- The class extends `ScheduledThreadPoolExecutor` and doesn't use `ThreadPoolExecutor` directly

## Test plan
- [x] Code compiles successfully with `mvn compile`
- [x] Code formatting verified with `mvn spotless:apply`
- [x] No behavioral changes, only removed an unused import