### PR TITLE
Fix constructor exception handling in JaxbSerializer

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
@@ -25,10 +25,13 @@ public final class GuidelineIO extends JaxbSerializer<Guideline<?>> {
 
     private Logger LOGGER = LogManager.getLogger();
 
-    public GuidelineIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
-            throws JAXBException {
+    public GuidelineIO(Class<? extends AnalyzedProperty> analyzedPropertyClass) {
         // analyzedPropertyClass parameter kept for API compatibility
-        this.context = getJAXBContext();
+        try {
+            this.context = getJAXBContext();
+        } catch (JAXBException e) {
+            throw new IllegalStateException("Failed to create JAXB context", e);
+        }
     }
 
     private JAXBContext getJAXBContext() throws JAXBException {

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencersIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencersIO.java
@@ -10,7 +10,6 @@ package de.rub.nds.scanner.core.report.rating;
 
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.util.JaxbSerializer;
-import jakarta.xml.bind.JAXBException;
 import java.util.Set;
 
 public class RatingInfluencersIO extends JaxbSerializer<RatingInfluencers> {
@@ -20,10 +19,8 @@ public class RatingInfluencersIO extends JaxbSerializer<RatingInfluencers> {
      * Creates a JAXB serializer configured to handle RatingInfluencers and related classes.
      *
      * @param analyzedPropertyClass the class of AnalyzedProperty to support in serialization
-     * @throws JAXBException if JAXB context creation fails
      */
-    public RatingInfluencersIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
-            throws JAXBException {
+    public RatingInfluencersIO(Class<? extends AnalyzedProperty> analyzedPropertyClass) {
         super(
                 Set.of(
                         RatingInfluencers.class,

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/RecommendationsIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/RecommendationsIO.java
@@ -10,7 +10,6 @@ package de.rub.nds.scanner.core.report.rating;
 
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.util.JaxbSerializer;
-import jakarta.xml.bind.JAXBException;
 import java.util.Set;
 
 public class RecommendationsIO extends JaxbSerializer<Recommendations> {
@@ -20,10 +19,8 @@ public class RecommendationsIO extends JaxbSerializer<Recommendations> {
      * a JAXB serializer configured to handle Recommendations and related classes.
      *
      * @param analyzedPropertyClass the class of AnalyzedProperty to support in serialization
-     * @throws JAXBException if JAXB context creation fails
      */
-    public RecommendationsIO(Class<? extends AnalyzedProperty> analyzedPropertyClass)
-            throws JAXBException {
+    public RecommendationsIO(Class<? extends AnalyzedProperty> analyzedPropertyClass) {
         super(
                 Set.of(
                         Recommendations.class,

--- a/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
@@ -37,8 +37,12 @@ public abstract class JaxbSerializer<T> {
 
     protected JaxbSerializer() {}
 
-    protected JaxbSerializer(Set<Class<?>> classesToBeBound) throws JAXBException {
-        this.context = getJAXBContext(classesToBeBound);
+    protected JaxbSerializer(Set<Class<?>> classesToBeBound) {
+        try {
+            this.context = getJAXBContext(classesToBeBound);
+        } catch (JAXBException e) {
+            throw new IllegalStateException("Failed to create JAXB context", e);
+        }
     }
 
     protected synchronized JAXBContext getJAXBContext(Set<Class<?>> classesToBeBound)

--- a/src/test/java/de/rub/nds/scanner/core/guideline/GuidelineIOTest.java
+++ b/src/test/java/de/rub/nds/scanner/core/guideline/GuidelineIOTest.java
@@ -15,7 +15,6 @@ import de.rub.nds.scanner.core.guideline.testutil.IOTestScanReport;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.AnalyzedPropertyCategory;
 import de.rub.nds.scanner.core.probe.result.TestResults;
-import jakarta.xml.bind.JAXBException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -46,7 +45,7 @@ class GuidelineIOTest {
     }
 
     @Test
-    void testConstructorWithAnalyzedPropertyClass() throws JAXBException {
+    void testConstructorWithAnalyzedPropertyClass() {
         GuidelineIO io = new GuidelineIO(TestAnalyzedProperty.class);
         assertNotNull(io);
     }

--- a/src/test/java/de/rub/nds/scanner/core/util/JaxbSerializerTest.java
+++ b/src/test/java/de/rub/nds/scanner/core/util/JaxbSerializerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Scanner Core - A Modular Framework for Probe Definition, Execution, and Result Analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class JaxbSerializerTest {
+
+    @XmlRootElement
+    static class ValidTestClass {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    // Interface which cannot be instantiated by JAXB
+    interface InvalidTestClass {
+        String getValue();
+    }
+
+    static class TestSerializer extends JaxbSerializer<ValidTestClass> {
+        public TestSerializer(Set<Class<?>> classes) {
+            super(classes);
+        }
+    }
+
+    @Test
+    void testConstructorWithValidClass() {
+        assertDoesNotThrow(() -> new TestSerializer(Set.of(ValidTestClass.class)));
+    }
+
+    @Test
+    void testConstructorWithInvalidClassThrowsIllegalStateException() {
+        // This should throw IllegalStateException instead of JAXBException
+        IllegalStateException exception =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> new TestSerializer(Set.of(InvalidTestClass.class)));
+
+        assertEquals("Failed to create JAXB context", exception.getMessage());
+        assertNotNull(exception.getCause());
+    }
+
+    @Test
+    void testConstructorWithMultipleClasses() {
+        // Test with multiple valid classes
+        assertDoesNotThrow(() -> new TestSerializer(Set.of(ValidTestClass.class, String.class)));
+    }
+
+    @Test
+    void testConstructorWithEmptyClassSet() {
+        // Empty set should still work
+        assertDoesNotThrow(() -> new TestSerializer(Set.of()));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed SpotBugs warning about constructors throwing exceptions
- Wrapped checked JAXBException in unchecked IllegalStateException
- Updated all subclasses to match new signature

## Changes
- Modified `JaxbSerializer` constructor to catch `JAXBException` and wrap it in `IllegalStateException`
- Updated `GuidelineIO`, `RatingInfluencersIO`, and `RecommendationsIO` to remove `throws JAXBException` declarations
- Added comprehensive unit tests to verify the exception handling behavior
- Updated existing test to remove unnecessary exception declaration

## Test plan
- [x] Added unit test `JaxbSerializerTest` to verify exception handling
- [x] All existing tests pass (102 tests)
- [x] Code formatting verified with `mvn spotless:check`
- [x] Build successful with `mvn clean compile`