### PR TITLE
Fix serialization issues in rating classes

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRatingInfluencer.java
@@ -18,6 +18,7 @@ import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.io.Serializable;
 import java.util.Objects;
 
 @XmlRootElement
@@ -30,7 +31,8 @@ import java.util.Objects;
             "referencedProperty",
             "referencedPropertyResult"
         })
-public class PropertyResultRatingInfluencer implements Comparable<PropertyResultRatingInfluencer> {
+public class PropertyResultRatingInfluencer
+        implements Serializable, Comparable<PropertyResultRatingInfluencer> {
 
     @XmlElement(type = TestResults.class, name = "result")
     @JsonIgnore

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRecommendation.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/PropertyResultRecommendation.java
@@ -15,11 +15,12 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlSeeAlso;
+import java.io.Serializable;
 
 @XmlRootElement
 @XmlSeeAlso({TestResults.class})
 @XmlAccessorType(XmlAccessType.FIELD)
-public class PropertyResultRecommendation {
+public class PropertyResultRecommendation implements Serializable {
 
     @XmlAnyElement(lax = true)
     private TestResult result;

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencer.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/RatingInfluencer.java
@@ -11,13 +11,14 @@ package de.rub.nds.scanner.core.report.rating;
 import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.result.TestResult;
 import jakarta.xml.bind.annotation.*;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class RatingInfluencer {
+public class RatingInfluencer implements Serializable {
 
     @XmlAnyElement(lax = true)
     private AnalyzedProperty analyzedProperty;

--- a/src/main/java/de/rub/nds/scanner/core/report/rating/Recommendation.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/rating/Recommendation.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.List;
             "propertyRecommendations"
         })
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Recommendation {
+public class Recommendation implements Serializable {
 
     static final String NO_INFORMATION_FOUND = "No detailed information available";
 

--- a/src/test/java/de/rub/nds/scanner/core/report/rating/SerializationTest.java
+++ b/src/test/java/de/rub/nds/scanner/core/report/rating/SerializationTest.java
@@ -1,0 +1,235 @@
+/*
+ * Scanner Core - A Modular Framework for Probe Definition, Execution, and Result Analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.report.rating;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import de.rub.nds.scanner.core.probe.AnalyzedProperty;
+import de.rub.nds.scanner.core.probe.AnalyzedPropertyCategory;
+import de.rub.nds.scanner.core.probe.result.TestResult;
+import java.io.*;
+import java.util.LinkedList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Test to verify serialization functionality of rating-related classes */
+public class SerializationTest {
+
+    @Test
+    public void testRatingInfluencersSerializable() throws IOException, ClassNotFoundException {
+        // Create test data
+        LinkedList<RatingInfluencer> influencers = new LinkedList<>();
+        RatingInfluencers ratingInfluencers = new RatingInfluencers(influencers);
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(ratingInfluencers);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        RatingInfluencers deserialized = (RatingInfluencers) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+        assertNotNull(deserialized.getRatingInfluencers());
+    }
+
+    @Test
+    public void testRecommendationsSerializable() throws IOException, ClassNotFoundException {
+        // Create test data
+        List<Recommendation> recs = new LinkedList<>();
+        Recommendations recommendations = new Recommendations(recs);
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(recommendations);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Recommendations deserialized = (Recommendations) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+        assertNotNull(deserialized.getRecommendations());
+    }
+
+    @Test
+    public void testRatingInfluencerSerializable() throws IOException, ClassNotFoundException {
+        // Create test data
+        RatingInfluencer influencer = new RatingInfluencer();
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(influencer);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        RatingInfluencer deserialized = (RatingInfluencer) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+    }
+
+    @Test
+    public void testRecommendationSerializable() throws IOException, ClassNotFoundException {
+        // Create test data
+        Recommendation recommendation = new Recommendation();
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(recommendation);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Recommendation deserialized = (Recommendation) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+    }
+
+    @Test
+    public void testPropertyResultRatingInfluencerSerializable()
+            throws IOException, ClassNotFoundException {
+        // Create test data with a mock TestResult implementation
+        TestResult mockResult = new MockTestResult();
+        PropertyResultRatingInfluencer influencer =
+                new PropertyResultRatingInfluencer(mockResult, 10);
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(influencer);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        PropertyResultRatingInfluencer deserialized =
+                (PropertyResultRatingInfluencer) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+        assertEquals(10, deserialized.getInfluence());
+    }
+
+    @Test
+    public void testPropertyResultRecommendationSerializable()
+            throws IOException, ClassNotFoundException {
+        // Create test data with a mock TestResult implementation
+        TestResult mockResult = new MockTestResult();
+        PropertyResultRecommendation recommendation =
+                new PropertyResultRecommendation(mockResult, "Status", "Handle it");
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(recommendation);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        PropertyResultRecommendation deserialized = (PropertyResultRecommendation) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+        assertEquals("Status", deserialized.getShortDescription());
+        assertEquals("Handle it", deserialized.getHandlingRecommendation());
+    }
+
+    @Test
+    public void testComplexSerializationScenario() throws IOException, ClassNotFoundException {
+        // Create a complex hierarchy
+        TestResult mockResult = new MockTestResult();
+        PropertyResultRatingInfluencer propInfluencer =
+                new PropertyResultRatingInfluencer(mockResult, 5);
+        List<PropertyResultRatingInfluencer> propInfluencers = new LinkedList<>();
+        propInfluencers.add(propInfluencer);
+
+        RatingInfluencer ratingInfluencer =
+                new RatingInfluencer(new MockAnalyzedProperty(), propInfluencers);
+        LinkedList<RatingInfluencer> influencers = new LinkedList<>();
+        influencers.add(ratingInfluencer);
+        RatingInfluencers ratingInfluencers = new RatingInfluencers(influencers);
+
+        // Test serialization
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(ratingInfluencers);
+        oos.close();
+
+        // Test deserialization
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        RatingInfluencers deserialized = (RatingInfluencers) ois.readObject();
+        ois.close();
+
+        assertNotNull(deserialized);
+        assertEquals(1, deserialized.getRatingInfluencers().size());
+        assertEquals(
+                1,
+                deserialized.getRatingInfluencers().get(0).getPropertyRatingInfluencers().size());
+    }
+
+    // Mock implementations for testing
+    private static class MockTestResult implements TestResult, Serializable {
+        @Override
+        public String getName() {
+            return "MockTestResult";
+        }
+
+        @Override
+        public boolean equalsExpectedResult(TestResult expectedResult) {
+            return this.equals(expectedResult);
+        }
+
+        @Override
+        public String toString() {
+            return "MockTestResult";
+        }
+    }
+
+    private static class MockAnalyzedProperty implements AnalyzedProperty, Serializable {
+        @Override
+        public String getName() {
+            return "MockProperty";
+        }
+
+        @Override
+        public AnalyzedPropertyCategory getCategory() {
+            return new MockAnalyzedPropertyCategory();
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+    }
+
+    private static class MockAnalyzedPropertyCategory
+            implements AnalyzedPropertyCategory, Serializable {
+        @Override
+        public String toString() {
+            return "MockCategory";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes SpotBugs warning: BAD_PRACTICE/SE_BAD_FIELD - Non-transient non-serializable instance field in serializable class
- Adds `Serializable` implementation to all rating-related classes that were missing it
- Adds comprehensive serialization tests to prevent regression

## Changes
- Made `RatingInfluencer` and `Recommendation` classes implement `Serializable`
- Made `PropertyResultRatingInfluencer` and `PropertyResultRecommendation` classes implement `Serializable`
- Added `SerializationTest` with comprehensive test coverage for all affected classes

## Test plan
- [x] Added unit tests for serialization/deserialization of all affected classes
- [x] All tests pass successfully
- [x] Code formatted with spotless
- [x] Project compiles without warnings