### PR TITLE
Fix default encoding issue in JaxbSerializer

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
+++ b/src/main/java/de/rub/nds/scanner/core/util/JaxbSerializer.java
@@ -83,7 +83,10 @@ public abstract class JaxbSerializer<T> {
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             transformer.transform(new JAXBSource(context, obj), new StreamResult(tempStream));
-            String xmlText = tempStream.toString().replaceAll("\r?\n", System.lineSeparator());
+            String xmlText =
+                    tempStream
+                            .toString(StandardCharsets.UTF_8)
+                            .replaceAll("\r?\n", System.lineSeparator());
             outputStream.write(xmlText.getBytes(StandardCharsets.UTF_8));
         } catch (TransformerException e) {
             LOGGER.warn(e);

--- a/src/test/java/de/rub/nds/scanner/core/util/JaxbSerializerTest.java
+++ b/src/test/java/de/rub/nds/scanner/core/util/JaxbSerializerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Scanner Core - A Modular Framework for Probe Definition, Execution, and Result Analysis.
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.scanner.core.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.xml.bind.*;
+import jakarta.xml.bind.annotation.*;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JaxbSerializerTest {
+
+    @TempDir private File tempDir;
+
+    private TestJaxbSerializer serializer;
+
+    @BeforeEach
+    void setUp() throws JAXBException {
+        serializer = new TestJaxbSerializer();
+    }
+
+    @Test
+    void testWriteToStreamWithUTF8Characters() throws JAXBException, IOException {
+        TestObject obj = new TestObject();
+        obj.setText("Test with UTF-8 characters: é, ñ, ü, 中文");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        serializer.write(baos, obj);
+
+        String result = baos.toString(StandardCharsets.UTF_8);
+        assertTrue(result.contains("Test with UTF-8 characters: é, ñ, ü, 中文"));
+    }
+
+    @Test
+    void testWriteToFileWithUTF8Characters() throws JAXBException, IOException, XMLStreamException {
+        TestObject obj = new TestObject();
+        obj.setText("Test with UTF-8 characters: é, ñ, ü, 中文");
+
+        File file = new File(tempDir, "test-utf8.xml");
+        serializer.write(file, obj);
+
+        TestObject readObj = serializer.read(file);
+        assertEquals("Test with UTF-8 characters: é, ñ, ü, 中文", readObj.getText());
+    }
+
+    @Test
+    void testReadFromStreamWithUTF8Characters() throws JAXBException, XMLStreamException {
+        String xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<testObject>\n"
+                        + "    <text>Test with UTF-8 characters: é, ñ, ü, 中文</text>\n"
+                        + "</testObject>";
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        TestObject obj = serializer.read(bais);
+
+        assertEquals("Test with UTF-8 characters: é, ñ, ü, 中文", obj.getText());
+    }
+
+    @XmlRootElement(name = "testObject")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class TestObject {
+        @XmlElement private String text;
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+    }
+
+    static class TestJaxbSerializer extends JaxbSerializer<TestObject> {
+        public TestJaxbSerializer() throws JAXBException {
+            super(Set.of(TestObject.class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed default encoding issue in JaxbSerializer.java line 86
- Changed `tempStream.toString()` to `tempStream.toString(StandardCharsets.UTF_8)` to explicitly specify UTF-8 encoding
- Added comprehensive unit tests to verify proper UTF-8 character handling

## Test plan
- [x] Added JaxbSerializerTest class with three test methods
- [x] Tests verify UTF-8 character handling in stream writing, file writing, and stream reading
- [x] All tests pass successfully
- [x] Code compiles without errors
- [x] Applied spotless formatting