### PR TITLE
Fix REC_CATCH_EXCEPTION in ProbeTypeConverter

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ProbeTypeConverter.java
@@ -9,6 +9,7 @@
 package de.rub.nds.scanner.core.probe;
 
 import com.beust.jcommander.IStringConverter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.reflections.Reflections;
@@ -46,7 +47,10 @@ public class ProbeTypeConverter implements IStringConverter<ProbeType> {
                 if (convertedType != null) {
                     return convertedType;
                 }
-            } catch (Exception ignored) {
+            } catch (NoSuchMethodException
+                    | IllegalAccessException
+                    | IllegalArgumentException
+                    | InvocationTargetException ignored) {
                 // Ignore conversion failures and try next method
             }
         }


### PR DESCRIPTION
## Summary
- Replaced generic Exception catch with specific exception types in ProbeTypeConverter
- Addresses static analysis warning about catching Exception when specific exceptions are thrown
- Improves code quality by being explicit about expected exceptions

## Changes
The reflection operations in the try block can throw:
- `NoSuchMethodException` from `getMethod()`
- `IllegalAccessException`, `IllegalArgumentException`, `InvocationTargetException` from `invoke()`

Changed the catch block to explicitly catch these specific exceptions instead of the generic Exception class.

## Test plan
- [x] Code compiles successfully
- [x] Spotless formatting applied
- [x] This is a refactoring that doesn't change behavior, only makes exception handling more specific