### PR TITLE
Fix: disable JarURLConnection caching in GuidelineIO to prevent concurrent scan failures

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
+++ b/src/main/java/de/rub/nds/scanner/core/guideline/GuidelineIO.java
@@ -89,8 +89,12 @@ public final class GuidelineIO extends JaxbSerializer<Guideline> {
                         .forEach(p -> xmlFilePaths.add(folder + "/" + p.getFileName().toString()));
             }
         } else if ("jar".equals(protocol)) {
-            // Running from a jar
+            // Running from a jar. Disable caching so each connection opens its own
+            // JarFile instance; the default cached instance is shared across threads
+            // and closing it (via try-with-resources) causes "zip file closed" errors
+            // in concurrent callers.
             JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
+            jarConnection.setUseCaches(false);
             try (JarFile jarFile = jarConnection.getJarFile()) {
                 Enumeration<JarEntry> entries = jarFile.entries();
                 while (entries.hasMoreElements()) {


### PR DESCRIPTION
## Problem

`GuidelineIO.listXmlFiles()` calls `jarConnection.getJarFile()` which, by default, returns a **shared, cached** `JarFile` instance. When one `TlsServerScanner` instance finishes and its try-with-resources block closes the `JarFile`, any concurrent scanner that received the same cached handle fails with:

```
java.lang.IllegalStateException: zip file closed
```

This only manifests when running multiple concurrent scans from a JAR (production deployments), not in development mode where the file protocol is used.

## Fix

Add `jarConnection.setUseCaches(false)` before calling `getJarFile()`. This causes the JDK to open a fresh, independent `JarFile` for each connection, so closing one does not affect others.

## References

- Issue: https://github.com/tls-attacker/TLS-Scanner-Development/issues/772
- Workaround in TLS-Crawler-Development: tls-attacker/TLS-Crawler-Development#115

---
*This PR was created with AI assistance.*