### PR TITLE
Merge release/v6.4.0 back into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>scanner-core</artifactId>
-    <version>6.3.1-SNAPSHOT</version>
+    <version>6.4.0</version>
 
     <name>Scanner Core</name>
     <description>A generic scanner framework which can execute a set of probes and combine the results into a report.</description>
@@ -60,7 +60,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/scanner-core.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/scanner-core.git</developerConnection>
-        <tag>v6.2.2</tag>
+        <tag>v6.4.0</tag>
         <url>https://github.com/tls-attacker/Scanner-Core</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>scanner-core</artifactId>
-    <version>6.4.0</version>
+    <version>6.4.1-SNAPSHOT</version>
 
     <name>Scanner Core</name>
     <description>A generic scanner framework which can execute a set of probes and combine the results into a report.</description>
@@ -60,7 +60,7 @@
     <scm>
         <connection>scm:git:https://github.com/tls-attacker/scanner-core.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/tls-attacker/scanner-core.git</developerConnection>
-        <tag>v6.4.0</tag>
+        <tag>v6.2.2</tag>
         <url>https://github.com/tls-attacker/Scanner-Core</url>
     </scm>
 


### PR DESCRIPTION
For whatever reason we have a 6.4.0 release but the version bump never made it to main