### PR TITLE
Distinguish not scheduled probes from erroneus not executed probes in report

### DIFF
--- a/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
+++ b/src/main/java/de/rub/nds/scanner/core/execution/Scanner.java
@@ -13,7 +13,9 @@ import de.rub.nds.scanner.core.config.ExecutorConfig;
 import de.rub.nds.scanner.core.guideline.Guideline;
 import de.rub.nds.scanner.core.guideline.GuidelineChecker;
 import de.rub.nds.scanner.core.passive.StatsWriter;
+import de.rub.nds.scanner.core.probe.AnalyzedProperty;
 import de.rub.nds.scanner.core.probe.ScannerProbe;
+import de.rub.nds.scanner.core.probe.result.TestResults;
 import de.rub.nds.scanner.core.report.ScanReport;
 import de.rub.nds.scanner.core.report.rating.ScoreReport;
 import de.rub.nds.scanner.core.report.rating.SiteReportRater;
@@ -200,6 +202,13 @@ public abstract class Scanner<
         if (!checkScanPrerequisites(report)) {
             LOGGER.info("Scan cannot be performed due to prerequisites not being fulfilled");
             return report;
+        }
+
+        // prefill report with NOT_TESTED_YET for all scheduled probes
+        for (ProbeT probe : probeList) {
+            for (AnalyzedProperty property : probe.getAnalyzedProperties()) {
+                report.putResult(property, TestResults.NOT_TESTED_YET);
+            }
         }
 
         // Scan Execution

--- a/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/ScannerProbe.java
@@ -71,6 +71,10 @@ public abstract class ScannerProbe<ReportT extends ScanReport, StateT>
         }
     }
 
+    public Set<AnalyzedProperty> getAnalyzedProperties() {
+        return propertiesMap.keySet();
+    }
+
     public final <T> void putIfFalse(
             AnalyzedProperty determiningProperty,
             AnalyzedProperty propertyToSet,

--- a/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
+++ b/src/main/java/de/rub/nds/scanner/core/probe/result/TestResults.java
@@ -24,7 +24,8 @@ public enum TestResults implements SummarizableTestResult {
     COULD_NOT_TEST,
     ERROR_DURING_TEST,
     UNCERTAIN,
-    UNSUPPORTED,
+    NOT_IMPLEMENTED,
+    NOT_SCHEDULED,
     NOT_TESTED_YET,
     UNASSIGNED_ERROR,
     TIMEOUT;

--- a/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
+++ b/src/main/java/de/rub/nds/scanner/core/report/ScanReport.java
@@ -108,10 +108,10 @@ public abstract class ScanReport {
      * Returns the test result for a specific property.
      *
      * @param property the property to get the result for
-     * @return the test result, or NOT_TESTED_YET if not found
+     * @return the test result, or NOT_SCHEDULED if not found
      */
     public synchronized TestResult getResult(AnalyzedProperty property) {
-        return resultMap.getOrDefault(property, TestResults.NOT_TESTED_YET);
+        return resultMap.getOrDefault(property, TestResults.NOT_SCHEDULED);
     }
 
     /**


### PR DESCRIPTION
The report is now prefilled with `NOT_EXECUTED_YET` for all scheduled probes. All other properties results return `NOT_SCHEDULED`.
`NOT_EXECUTED_YET` is now considered an internal error if it persists until the report is done.

Before this, if a probe was not scheduled, the scanner would print "not scheduled yet" in the final report.